### PR TITLE
Add CLI tool to manage conversion tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@
 # vendor/
 
 /misc/config/config.yaml
-/acceleration-service
+/acceld
+/accelctl

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ GIT_COMMIT := $(shell git rev-list -1 HEAD)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 CWD := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
-# Build binary to ./acceleration-service
+# Build binary to ./
 default: check
-	go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" ./cmd/acceleration-service
+	go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" ./cmd/acceld
+	go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" ./cmd/accelctl
 
 install-check-tools:
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.42.1

--- a/README.md
+++ b/README.md
@@ -72,15 +72,24 @@ root        929  0.5  0.5 2222284 22368 ?       Ssl  Sep16   4:27 /usr/local/bin
 2. Boot daemon to serve webhook request in PUSH_ARTIFACT event
 
 ``` shell
-$ ./acceleration-service --config ./misc/config/config.yaml
+$ ./acceld --config ./misc/config/config.yaml
 ```
 
-### Test with pushing image
+### Test image conversion
 
-1. Push a test image to Harbor
+1. Trigger image conversion
+
+We can either push an image to Harbor:
 
 ``` shell
 $ docker push <harbor-service-address>/library/nginx:latest
+```
+
+Or convert an existing image manually using the `accelctl` CLI tool:
+
+``` shell
+$ ./accelctl task create <harbor-service-address>/library/nginx:latest
+$ ./accelctl list
 ```
 
 2. Got converted image

--- a/cmd/accelctl/main.go
+++ b/cmd/accelctl/main.go
@@ -1,0 +1,128 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+
+	"github.com/goharbor/acceleration-service/pkg/client"
+)
+
+var versionGitCommit string
+var versionBuildTime string
+
+var ctl *client.Client
+
+func ellipsis(txt string, max int) string {
+	if len(txt) > max {
+		return fmt.Sprintf("%s...", txt[0:max])
+	}
+	return txt
+}
+
+func main() {
+	logrus.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp:   true,
+		TimestampFormat: time.RFC3339Nano,
+	})
+
+	version := fmt.Sprintf("%s.%s", versionGitCommit, versionBuildTime)
+
+	app := &cli.App{
+		Name:    "accelctl",
+		Usage:   "A CLI tool to manage acceleration service",
+		Version: version,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "addr", Value: "localhost:2077", Usage: "Service address in format <host:port>."},
+		},
+		Before: func(c *cli.Context) error {
+			ctl = client.NewClient(c.String("addr"))
+			return nil
+		},
+		Commands: []*cli.Command{
+			{
+				Name:  "task",
+				Usage: "Manage conversion tasks",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "create",
+						Usage: "Convert a source to an acceleration image",
+						Flags: []cli.Flag{
+							&cli.BoolFlag{Name: "sync", Value: false},
+						},
+						ArgsUsage: "[SOURCE]",
+						Action: func(c *cli.Context) error {
+							source := c.Args().First()
+							if source == "" {
+								return fmt.Errorf("source is required")
+							}
+
+							sync := c.Bool("sync")
+							if sync {
+								logrus.Info("Waiting task to be completed...")
+							}
+
+							if err := ctl.CreateTask(source, sync); err != nil {
+								return err
+							}
+
+							if sync {
+								logrus.Info("Task has been completed.")
+							} else {
+								logrus.Info("Submitted asynchronous task, check status by `task list`.")
+							}
+
+							return nil
+						},
+					},
+					{
+						Name:    "list",
+						Aliases: []string{"ls"},
+						Usage:   "List image conversion tasks",
+						Action: func(c *cli.Context) error {
+							tasks, err := ctl.ListTask()
+							if err != nil {
+								return err
+							}
+
+							writer := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', tabwriter.AlignRight)
+							fmt.Fprintln(writer, "ID\tCREATED\tSTATUS\tSOURCE\tREASON")
+							for _, task := range tasks {
+								created := task.Created.Format("2006-01-02 15:04:05")
+								source := ellipsis(task.Source, 80)
+								reason := ellipsis(task.Reason, 80)
+								fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\n", task.ID, created, task.Status, source, reason)
+							}
+							writer.Flush()
+
+							return nil
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}

--- a/cmd/acceld/main.go
+++ b/cmd/acceld/main.go
@@ -40,7 +40,7 @@ func main() {
 	logrus.Infof("Version: %s\n", version)
 
 	app := &cli.App{
-		Name:    "acceleration-service",
+		Name:    "acceld",
 		Usage:   "Provides a general service to support image acceleration based on kinds of accelerator like Nydus and eStargz etc.",
 		Version: version,
 		Flags: []cli.Flag{

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/stargz-snapshotter/estargz v0.9.0
 	github.com/docker/cli v20.10.9+incompatible
 	github.com/goharbor/harbor/src v0.0.0-20211021012518-bc6a7f65a6fa
+	github.com/google/uuid v1.2.0
 	github.com/labstack/echo-contrib v0.11.0
 	github.com/labstack/echo/v4 v4.6.1
 	github.com/labstack/gommon v0.3.0

--- a/pkg/client/convert.go
+++ b/pkg/client/convert.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/goharbor/acceleration-service/pkg/task"
+	"github.com/goharbor/harbor/src/controller/event"
+	"github.com/goharbor/harbor/src/pkg/notifier/model"
+	"github.com/pkg/errors"
+)
+
+func (client *Client) CreateTask(src string, sync bool) error {
+	payload := model.Payload{
+		Type: event.TopicPushArtifact,
+		EventData: &model.EventData{
+			Resources: []*model.Resource{
+				{
+					ResourceURL: src,
+				},
+			},
+		},
+	}
+
+	data, err := marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/api/v1/conversions?sync=%s", strconv.FormatBool(sync))
+	resp, err := client.Request(http.MethodPost, path, data, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func (client *Client) ListTask() ([]task.Task, error) {
+	resp, err := client.Request(http.MethodGet, "/api/v1/conversions", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var tasks []task.Task
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&tasks); err != nil {
+		return nil, errors.Wrap(err, "decode response")
+	}
+
+	return tasks, nil
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -19,10 +19,13 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/sirupsen/logrus"
 
 	"github.com/goharbor/acceleration-service/pkg/handler"
 	"github.com/goharbor/acceleration-service/pkg/server/util"
 )
+
+var logger = logrus.WithField("module", "api")
 
 type Router interface {
 	Register(server *echo.Echo) error
@@ -39,7 +42,8 @@ func NewLocalRouter(handler handler.Handler) Router {
 }
 
 func (router *LocalRouter) Register(server *echo.Echo) error {
-	server.POST("/api/v1/conversions", router.Convert)
+	server.POST("/api/v1/conversions", router.CreateTask)
+	server.GET("/api/v1/conversions", router.ListTask)
 
 	// Any unexpected endpoint will return an error.
 	server.Any("*", func(ctx echo.Context) error {

--- a/pkg/router/task_list.go
+++ b/pkg/router/task_list.go
@@ -1,0 +1,27 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+import (
+	"net/http"
+
+	"github.com/goharbor/acceleration-service/pkg/task"
+	"github.com/labstack/echo/v4"
+)
+
+func (r *LocalRouter) ListTask(ctx echo.Context) error {
+	tasks := task.Manager.List()
+	return ctx.JSON(http.StatusOK, tasks)
+}

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -1,0 +1,119 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const taskMaximumKeepPeriod = time.Hour * 24
+
+const StatusProcessing = "PROCESSING"
+const StatusCompleted = "COMPLETED"
+const StatusFailed = "FAILED"
+
+type Task struct {
+	ID       string     `json:"id"`
+	Created  time.Time  `json:"created"`
+	Finished *time.Time `json:"finished"`
+	Source   string     `json:"source"`
+	Status   string     `json:"status"`
+	Reason   string     `json:"reason"`
+}
+
+type manager struct {
+	mutex sync.Mutex
+	tasks map[string]*Task
+}
+
+var Manager *manager
+
+func init() {
+	Manager = &manager{
+		mutex: sync.Mutex{},
+		tasks: make(map[string]*Task),
+	}
+}
+
+func (t *Task) IsExpired() bool {
+	if t.Status != StatusProcessing &&
+		time.Now().After(t.Finished.Add(taskMaximumKeepPeriod)) {
+		return true
+	}
+	return false
+}
+
+func (m *manager) Create(source string) string {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	id := uuid.NewString()
+
+	m.tasks[id] = &Task{
+		ID:       id,
+		Created:  time.Now(),
+		Finished: nil,
+		Source:   source,
+		Status:   StatusProcessing,
+		Reason:   "",
+	}
+
+	return id
+}
+
+func (m *manager) Finish(id string, err error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// Update task status.
+	task := m.tasks[id]
+	if task != nil {
+		if err != nil {
+			task.Status = StatusFailed
+			task.Reason = err.Error()
+		} else {
+			task.Status = StatusCompleted
+		}
+		now := time.Now()
+		task.Finished = &now
+	}
+
+	// Evict expired tasks.
+	for id, task := range m.tasks {
+		if task.IsExpired() {
+			delete(m.tasks, id)
+		}
+	}
+}
+
+func (m *manager) List() []*Task {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	tasks := make([]*Task, 0)
+	for _, task := range m.tasks {
+		tasks = append(tasks, task)
+	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].Created.After(tasks[j].Created)
+	})
+
+	return tasks
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/goharbor/acceleration-service/pkg/client"
 	"github.com/goharbor/acceleration-service/pkg/config"
 	"github.com/goharbor/acceleration-service/pkg/daemon"
 )
 
 type IntegrationTestSuite struct {
-	client *Client
+	client *client.Client
 	suite.Suite
 }
 
@@ -26,8 +27,8 @@ func (suite *IntegrationTestSuite) startDaemon(cfg *config.Config) {
 	}()
 }
 
-func (suite *IntegrationTestSuite) newClient(cfg *config.Config) *Client {
-	return NewClient(&suite.Suite, fmt.Sprintf("127.0.0.1:%s", cfg.Server.Port))
+func (suite *IntegrationTestSuite) newClient(cfg *config.Config) *client.Client {
+	return client.NewClient(fmt.Sprintf("127.0.0.1:%s", cfg.Server.Port))
 }
 
 func (suite *IntegrationTestSuite) cleanUp() {


### PR DESCRIPTION
Add a CLI tool named `accelctl` for creating tasks and listing their status.

Usage:

```
$ accelctl task create <source-image-reference>
$ accelctl task list
```

Close https://github.com/goharbor/acceleration-service/issues/6

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>