### PR TITLE
Nydus: support localfs backend

### DIFF
--- a/misc/config/config.yaml.nydus.tmpl
+++ b/misc/config/config.yaml.nydus.tmpl
@@ -44,9 +44,11 @@ converter:
       builder: /usr/bin/nydus-image
       # specify nydus format version, possible values: 5, 6
       rafs_version: 5
-      # specify a storage backend for storing nydus blob, optional, possible values: oss
+      # specify a storage backend for storing nydus blob, optional, possible values: oss, localfs
       # backend_type: oss
       # backend_config: '{"endpoint":"","access_key_id":"","access_key_secret":"","bucket_name":""}'
+      # backend_type: localfs
+      # backend_config: '{"dir":"/path/to/dir"}'
   rules:
     # add suffix to tag of source image reference as target image reference
     - tag_suffix: -nydus

--- a/pkg/driver/nydus/backend/backend.go
+++ b/pkg/driver/nydus/backend/backend.go
@@ -42,6 +42,8 @@ func NewBackend(_type string, config []byte) (Backend, error) {
 	switch _type {
 	case BackendTypeOSS:
 		return newOSSBackend(config)
+	case BackendTypeLocalFS:
+		return newLocalFSBackend(config)
 	default:
 		return nil, fmt.Errorf("unsupported backend type %s", _type)
 	}

--- a/pkg/driver/nydus/backend/localfs.go
+++ b/pkg/driver/nydus/backend/localfs.go
@@ -1,0 +1,116 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	BackendTypeLocalFS = "localfs"
+)
+
+type LocalFSBackend struct {
+	dir string
+}
+
+func moveFile(src, dst string) error {
+	err := os.Rename(src, dst)
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to rename %s to %s, try to copy", src, dst)
+	} else {
+		return nil
+	}
+
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return errors.Wrapf(err, "open source file: %s", src)
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return errors.Wrapf(err, "create destination file: %s", dst)
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return errors.Wrapf(err, "copy file %s to %s", src, dst)
+	}
+
+	return nil
+}
+
+func newLocalFSBackend(rawConfig []byte) (*LocalFSBackend, error) {
+	var configMap map[string]string
+	if err := json.Unmarshal(rawConfig, &configMap); err != nil {
+		return nil, errors.Wrap(err, "parse LocalFS storage backend configuration")
+	}
+
+	dir, ok := configMap["dir"]
+	if !ok {
+		return nil, fmt.Errorf("no `dir` option is specified")
+	}
+
+	return &LocalFSBackend{
+		dir: dir,
+	}, nil
+}
+
+func (b *LocalFSBackend) dstPath(blobID string) string {
+	return path.Join(b.dir, blobID)
+}
+
+func (b *LocalFSBackend) Push(ctx context.Context, blobPath string) error {
+	if err := os.MkdirAll(b.dir, 0755); err != nil {
+		return errors.Wrap(err, "create directory in localfs backend")
+	}
+
+	blobID := path.Base(blobPath)
+	dstPath := b.dstPath(blobID)
+
+	if err := moveFile(blobPath, dstPath); err != nil {
+		return errors.Wrap(err, "move blob file in localfs backend")
+	}
+
+	return nil
+}
+
+func (b *LocalFSBackend) Check(blobID string) (bool, error) {
+	dstPath := b.dstPath(blobID)
+
+	info, err := os.Stat(dstPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return !info.IsDir(), nil
+}
+
+func (b *LocalFSBackend) Type() string {
+	return BackendTypeLocalFS
+}


### PR DESCRIPTION
Support for writing nydus blob to a specified directory, it's used in the case where the user wants to handle nydus blob themselves (upload blobs to the specified remote storage and do blob garbage collection by themselves).

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>