### PR TITLE
Accelctl: support one-time mode

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,8 +44,19 @@ jobs:
 
     - name: Test Nydus Driver
       run: |
+        NYDUS_VERSION=2.0.0-rc.0
+
+        # Download nydus components
+        wget https://github.com/dragonflyoss/image-service/releases/download/v$NYDUS_VERSION/nydus-static-v$NYDUS_VERSION-x86_64.tgz
+        tar xzvf nydus-static-v$NYDUS_VERSION-x86_64.tgz
+        mkdir -p /usr/bin
+        sudo mv nydus-static/nydus-image nydus-static/nydusd-fusedev nydus-static/nydusify /usr/bin/
         ./script/integration/nydus/test.sh ${{ env.OCI_IMAGE_NAME }}
 
     - name: Test eStargz Driver
       run: |
         ./script/integration/estargz/test.sh ${{ env.OCI_IMAGE_NAME }}
+
+    - name: Test one-time mode
+      run: |
+        ./script/integration/one-time.sh ${{ env.OCI_IMAGE_NAME }}

--- a/README.md
+++ b/README.md
@@ -108,3 +108,18 @@ INFO[2021-09-17T05:44:04.317992888Z] converted image 192.168.1.1/library/nginx:l
 ```
 
 After that, we will find converted artifact in Harbor interface with name `<harbor-service-address>/nginx:latest-nydus`.
+
+### One-time mode
+
+One-time mode allows to do a conversion without starting the `acceld` service (still requires a local containerd service), using `accelctl` like this:
+
+```
+$ accelctl convert --config ./misc/config/config.yaml 192.168.1.1/library/nginx:latest
+
+INFO[2022-01-28T03:39:28.039029557Z] pulling image 192.168.1.1/library/nginx:latest     module=converter
+INFO[2022-01-28T03:39:28.075375146Z] pulled image 192.168.1.1/library/nginx:latest      module=converter
+INFO[2022-01-28T03:39:28.075530522Z] converting image 192.168.1.1/library/nginx:latest  module=converter
+INFO[2022-01-28T03:39:29.561103924Z] converted image 192.168.1.1/library/nginx:latest-nydus  module=converter
+INFO[2022-01-28T03:39:29.561197593Z] pushing image 192.168.1.1/library/nginx:latest-nydus  module=converter
+INFO[2022-01-28T03:39:29.587585066Z] pushed image 192.168.1.1/library/nginx:latest-nydus  module=converter
+```

--- a/script/integration/one-time.sh
+++ b/script/integration/one-time.sh
@@ -4,12 +4,8 @@ set -euo pipefail
 
 OCI_IMAGE_NAME=$1
 
-# Start acceld service
-sudo nohup ./acceld --config ./misc/config/config.yaml.nydus.tmpl &> acceld.log &
-sleep 1
-
-# Convert image by accelctl
-sudo ./accelctl task create --sync localhost/library/$OCI_IMAGE_NAME:latest
+# Convert image by accelctl in one-time mode
+sudo ./accelctl convert --config ./misc/config/config.yaml.nydus.tmpl localhost/library/$OCI_IMAGE_NAME:latest
 
 # Verify filesystem consistency for converted image
 sudo /usr/bin/nydusify check \
@@ -19,6 +15,3 @@ sudo /usr/bin/nydusify check \
   --target localhost/library/$OCI_IMAGE_NAME:latest-nydus \
   --backend-type registry \
   --backend-config "{\"scheme\":\"http\",\"host\":\"localhost\",\"repo\":\"library/$OCI_IMAGE_NAME\",\"auth\":\"YWRtaW46SGFyYm9yMTIzNDU=\"}"
-
-# Gracefully exit acceld
-sudo pkill -SIGINT acceld


### PR DESCRIPTION
Some users want to do a one-time image conversion without starting
acceld service, so we can provide a one-time mode that allows
accelctl to convert images locally:

```
accelctl convert --config /path/to/config.yaml localhost/library/nginx:latest
```

Close #21 

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>