### PR TITLE
Nydus: support rafs v6 version

### DIFF
--- a/misc/config/config.yaml.nydus.tmpl
+++ b/misc/config/config.yaml.nydus.tmpl
@@ -40,9 +40,9 @@ converter:
     config:
       work_dir: /tmp
       # `nydus-image` binary path, download it from:
-      # https://github.com/imeoer/image-service/releases/download/v1.0.0/nydus-image
-      builder: /usr/bin/nydus-image
-      # specify nydus format version, possible values: 5, 6
+      # https://github.com/dragonflyoss/image-service/releases (require v2.0.0 or higher)
+      builder: nydus-image
+      # specify nydus format version, possible values: `5`, `6` (EROFS-compatible), default is `5`
       rafs_version: 5
       # specify a storage backend for storing nydus blob, optional, possible values: oss
       # backend_type: oss

--- a/pkg/driver/nydus/builder/builder.go
+++ b/pkg/driver/nydus/builder/builder.go
@@ -37,6 +37,8 @@ type Option struct {
 	DiffSkipLayer      *int
 
 	OutputJSONPath string
+
+	RafsVersion string
 }
 
 type Builder struct {
@@ -79,7 +81,14 @@ func (builder *Builder) Run(option Option) (*Output, error) {
 		"--source-type",
 		"diff",
 		"--diff-overlay-hint",
+		"--fs-version",
+		option.RafsVersion,
 	}
+	if option.RafsVersion != "" {
+		// FIXME: these options should be handled automatically in builder (nydus-image).
+		args = append(args, "--disable-check")
+	}
+
 	args = append(args, option.DiffLayerPaths...)
 	args = append(args, option.DiffHintLayerPaths...)
 	if option.DiffSkipLayer != nil {

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -59,7 +59,13 @@ func New(cfg map[string]string) (*Driver, error) {
 		}
 	}
 
-	p, err := packer.New(workDir, builderPath)
+	rafsVersion := cfg["rafs_version"]
+
+	p, err := packer.New(packer.Option{
+		WorkDir:     workDir,
+		BuilderPath: builderPath,
+		RafsVersion: rafsVersion,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "create nydus packer")
 	}

--- a/pkg/driver/nydus/packer/layer.go
+++ b/pkg/driver/nydus/packer/layer.go
@@ -63,6 +63,8 @@ type Layer interface {
 type BuildLayer struct {
 	Layer
 
+	rafsVersion string
+
 	parent *BuildLayer
 
 	mounts       []mount.Mount
@@ -208,8 +210,9 @@ func (layer *BuildLayer) exportBootstrap(ctx context.Context, sg *singleflight.G
 			Annotations: map[string]string{
 				// Use `containerd.io/uncompressed` to generate DiffID of
 				// layer defined in OCI spec.
-				utils.LayerAnnotationUncompressed:   uncompressedDigest.String(),
-				utils.LayerAnnotationNydusBootstrap: "true",
+				utils.LayerAnnotationUncompressed:     uncompressedDigest.String(),
+				utils.LayerAnnotationNydusBootstrap:   "true",
+				utils.LayerAnnotationNydusRAFSVersion: layer.rafsVersion,
 			},
 		}
 

--- a/pkg/driver/nydus/packer/packer.go
+++ b/pkg/driver/nydus/packer/packer.go
@@ -42,13 +42,25 @@ type Descriptor struct {
 type Packer struct {
 	parentWorkDir string
 	builderPath   string
+	rafsVersion   string
 	sg            singleflight.Group
 }
 
-func New(parentWorkDir, builderPath string) (*Packer, error) {
+type Option struct {
+	WorkDir     string
+	BuilderPath string
+	RafsVersion string
+}
+
+func New(option Option) (*Packer, error) {
+	if option.RafsVersion == "" {
+		option.RafsVersion = "5"
+	}
+
 	return &Packer{
-		parentWorkDir: parentWorkDir,
-		builderPath:   builderPath,
+		parentWorkDir: option.WorkDir,
+		builderPath:   option.BuilderPath,
+		rafsVersion:   option.RafsVersion,
 	}, nil
 }
 
@@ -129,6 +141,7 @@ func (p *Packer) diffBuild(ctx context.Context, workDir string, layers []*BuildL
 		DiffSkipLayer:      diffSkip,
 
 		OutputJSONPath: outputJSONPath,
+		RafsVersion:    p.rafsVersion,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "build layers %v %v", diffPaths, diffHintPaths)
@@ -176,8 +189,9 @@ func (p *Packer) Build(ctx context.Context, layers []Layer) ([]Descriptor, error
 		}
 
 		buildLayer := BuildLayer{
-			Layer:  layer,
-			parent: parent,
+			Layer:       layer,
+			rafsVersion: p.rafsVersion,
+			parent:      parent,
 		}
 		parent = &buildLayer
 

--- a/pkg/driver/nydus/utils/constant.go
+++ b/pkg/driver/nydus/utils/constant.go
@@ -19,10 +19,11 @@ const (
 	MediaTypeNydusBlob       = "application/vnd.oci.image.layer.nydus.blob.v1"
 	BootstrapFileNameInLayer = "image/image.boot"
 
-	LayerAnnotationNydusBlob      = "containerd.io/snapshot/nydus-blob"
-	LayerAnnotationNydusBootstrap = "containerd.io/snapshot/nydus-bootstrap"
+	LayerAnnotationNydusBlob        = "containerd.io/snapshot/nydus-blob"
+	LayerAnnotationNydusBootstrap   = "containerd.io/snapshot/nydus-bootstrap"
+	LayerAnnotationNydusRAFSVersion = "containerd.io/snapshot/nydus-rafs-version"
 
 	LayerAnnotationUncompressed = "containerd.io/uncompressed"
 )
 
-var NydusAnnotations = []string{LayerAnnotationNydusBlob, LayerAnnotationNydusBootstrap}
+var NydusAnnotations = []string{LayerAnnotationNydusBlob, LayerAnnotationNydusBootstrap, LayerAnnotationNydusRAFSVersion}


### PR DESCRIPTION
- Support to build nydus RAFS v6 version format (EROFS-compatible).
- Record nydus RAFS version to the annotation of bootstrap layer.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>