### PR TITLE
Nydus: support merging manifest

### DIFF
--- a/misc/config/config.yaml.nydus.tmpl
+++ b/misc/config/config.yaml.nydus.tmpl
@@ -44,6 +44,8 @@ converter:
       builder: nydus-image
       # specify nydus format version, possible values: `5`, `6` (EROFS-compatible), default is `5`
       rafs_version: 5
+      # ensure that both OCI v1 manifest and nydus manifest are present in the target image.
+      merge_manifest: false
       # specify a storage backend for storing nydus blob, optional, possible values: oss, localfs
       # backend_type: oss
       # backend_config: '{"endpoint":"","access_key_id":"","access_key_secret":"","bucket_name":""}'

--- a/misc/config/config.yaml.nydus.tmpl
+++ b/misc/config/config.yaml.nydus.tmpl
@@ -44,7 +44,8 @@ converter:
       builder: nydus-image
       # specify nydus format version, possible values: `5`, `6` (EROFS-compatible), default is `5`
       rafs_version: 5
-      # ensure that both OCI v1 manifest and nydus manifest are present in the target image.
+      # ensure that both OCIv1 manifest and nydus manifest are present as manifest index in the target image.
+      # it's used for containerd to support running OCIv1 image or nydus image simultaneously with a single image reference.
       merge_manifest: false
       # specify a storage backend for storing nydus blob, optional, possible values: oss, localfs
       # backend_type: oss

--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/goharbor/acceleration-service/pkg/config"
+	nydusUtils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
 	"github.com/goharbor/acceleration-service/pkg/remote"
 )
 
@@ -93,9 +94,11 @@ func (pvd *LocalProvider) Pull(ctx context.Context, ref string) error {
 		return errors.Wrapf(err, "get resolver for %s", ref)
 	}
 
+	platformMatcher := nydusUtils.ExcludeNydusPlatformComparer{MatchComparer: platforms.All}
+
 	opts := []containerd.RemoteOpt{
 		// TODO: sets max concurrent downloaded layer limit by containerd.WithMaxConcurrentDownloads.
-		containerd.WithPlatformMatcher(platforms.All),
+		containerd.WithPlatformMatcher(platformMatcher),
 		containerd.WithImageHandler(images.HandlerFunc(
 			func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 				if images.IsLayerType(desc.MediaType) {
@@ -112,9 +115,9 @@ func (pvd *LocalProvider) Pull(ctx context.Context, ref string) error {
 	if err != nil {
 		return errors.Wrap(err, "pull source image")
 	}
-	pvd.image = containerd.NewImageWithPlatform(pvd.client, image, platforms.DefaultStrict())
+	pvd.image = containerd.NewImageWithPlatform(pvd.client, image, platformMatcher)
 
-	// Unpack the image (default platform only)
+	// Unpack the source image.
 	return pvd.image.Unpack(ctx, "")
 }
 

--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -94,6 +94,7 @@ func (pvd *LocalProvider) Pull(ctx context.Context, ref string) error {
 		return errors.Wrapf(err, "get resolver for %s", ref)
 	}
 
+	// TODO: enable to configure the target platforms.
 	platformMatcher := nydusUtils.ExcludeNydusPlatformComparer{MatchComparer: platforms.All}
 
 	opts := []containerd.RemoteOpt{

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -15,26 +15,37 @@
 package nydus
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
+	imageContent "github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
+	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/acceleration-service/pkg/content"
 	"github.com/goharbor/acceleration-service/pkg/driver/nydus/backend"
 	"github.com/goharbor/acceleration-service/pkg/driver/nydus/export"
 	"github.com/goharbor/acceleration-service/pkg/driver/nydus/packer"
+	"github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
 )
 
+const supportedOS = "linux"
+
 type Driver struct {
-	backend backend.Backend
-	packer  *packer.Packer
+	backend       backend.Backend
+	packer        *packer.Packer
+	mergeManifest bool
 }
 
 func New(cfg map[string]string) (*Driver, error) {
@@ -49,6 +60,16 @@ func New(cfg map[string]string) (*Driver, error) {
 	}
 
 	var err error
+
+	_mergeManifest := cfg["merge_manifest"]
+	mergeManifest := false
+	if _mergeManifest != "" {
+		mergeManifest, err = strconv.ParseBool(_mergeManifest)
+		if err != nil {
+			return nil, fmt.Errorf("invalid merge_manifest option")
+		}
+	}
+
 	var _backend backend.Backend
 	backendType := cfg["backend_type"]
 	backendConfig := cfg["backend_config"]
@@ -71,26 +92,46 @@ func New(cfg map[string]string) (*Driver, error) {
 	}
 
 	return &Driver{
-		packer:  p,
-		backend: _backend,
+		packer:        p,
+		backend:       _backend,
+		mergeManifest: mergeManifest,
 	}, nil
 }
 
-func (nydus *Driver) Convert(ctx context.Context, content content.Provider) (*ocispec.Descriptor, error) {
+func (nydus *Driver) makeManifestIndex(ctx context.Context, content content.Provider, descs []ocispec.Descriptor) (*ocispec.Descriptor, error) {
+	index := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests: descs,
+	}
+
+	indexDesc, indexBytes, err := utils.MarshalToDesc(index, ocispec.MediaTypeImageIndex)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal image manifest index")
+	}
+
+	labels := map[string]string{}
+	labels["containerd.io/gc.ref.content.0"] = indexDesc.Digest.String()
+	if err := imageContent.WriteBlob(
+		ctx, content.ContentStore(), indexDesc.Digest.String(), bytes.NewReader(indexBytes), *indexDesc, imageContent.WithLabels(labels),
+	); err != nil {
+		return nil, errors.Wrap(err, "write image manifest")
+	}
+
+	return indexDesc, nil
+}
+
+func (nydus *Driver) convert(ctx context.Context, src ocispec.Manifest, content content.Provider) (*ocispec.Descriptor, error) {
 	diffIDs, err := content.Image().RootFS(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "get diff ids from containerd")
 	}
 
-	sourceManifest, err := images.Manifest(ctx, content.Image().ContentStore(), content.Image().Target(), platforms.Default())
-	if err != nil {
-		return nil, errors.Wrap(err, "get image manifest from containerd")
-	}
-
 	layers := []packer.Layer{}
 
 	var chain []digest.Digest
-	for idx := range sourceManifest.Layers {
+	for idx := range src.Layers {
 		chain = append(chain, diffIDs[idx])
 		upper := identity.ChainID(chain).String()
 
@@ -113,4 +154,88 @@ func (nydus *Driver) Convert(ctx context.Context, content content.Provider) (*oc
 	}
 
 	return desc, nil
+}
+
+func (nydus *Driver) Convert(ctx context.Context, content content.Provider) (*ocispec.Descriptor, error) {
+	provider := content.Image().ContentStore()
+
+	descs, err := utils.GetManifests(ctx, provider, content.Image().Target())
+	if err != nil {
+		return nil, errors.Wrap(err, "get image manifest list")
+	}
+	targetDescs := []ocispec.Descriptor{}
+
+	for _, srcDesc := range descs {
+		manifest, err := images.Manifest(ctx, provider, srcDesc, platforms.All)
+		if err != nil {
+			return nil, errors.Wrap(err, "get image manifest")
+		}
+
+		configBytes, err := imageContent.ReadBlob(ctx, provider, manifest.Config)
+		if err != nil {
+			return nil, err
+		}
+
+		platform := srcDesc.Platform
+		if platform == nil {
+			var srcConfig ocispec.Image
+			if err := json.Unmarshal(configBytes, &srcConfig); err != nil {
+				return nil, err
+			}
+			_platform := platforms.Normalize(ocispec.Platform{
+				Architecture: srcConfig.Architecture,
+				OS:           srcConfig.OS,
+				OSVersion:    srcConfig.OSVersion,
+				OSFeatures:   srcConfig.OSFeatures,
+				Variant:      srcConfig.Variant,
+			})
+			platform = &_platform
+		}
+		supportedPlatform := false
+		if platform != nil && platform.OS == supportedOS {
+			supportedPlatform = true
+		}
+
+		if !supportedPlatform {
+			logrus.Warnf("skip unsupported platform %v", platform)
+			continue
+		}
+
+		if utils.IsNydusPlatform(platform) || utils.IsNydusManifest(&manifest) {
+			// Skip the conversion of existing nydus manifest.
+			logrus.Warnf("skip existing nydus manifest %v", platform)
+			continue
+		}
+
+		if nydus.mergeManifest {
+			// Ensure that both OCI v1 manifest and nydus manifest are present in the target manifest index.
+			// The nydus manifest is marked with `"os.features": [ "nydus.remoteimage.v1" ]`.
+			// Example: https://github.com/dragonflyoss/image-service/blob/d3e16a4434ec58886531a3348efc1a25dac6ede9/contrib/nydusify/examples/manifest/index.json
+			targetDescs = append(targetDescs, srcDesc)
+		}
+
+		nydusDesc, err := nydus.convert(ctx, manifest, content)
+		if err != nil {
+			return nil, errors.Wrapf(err, "convert for platform %v", platform)
+		}
+
+		if nydus.mergeManifest {
+			if nydusDesc.Platform == nil {
+				nydusDesc.Platform = platform
+			}
+			nydusDesc.Platform.OSFeatures = []string{utils.ManifestOSFeatureNydus}
+		}
+
+		targetDescs = append(targetDescs, *nydusDesc)
+	}
+
+	if len(targetDescs) == 0 {
+		return nil, fmt.Errorf("not found supported platform")
+	}
+
+	if len(targetDescs) == 1 {
+		return &targetDescs[0], nil
+	}
+
+	return nydus.makeManifestIndex(ctx, content, targetDescs)
 }


### PR DESCRIPTION
Support `merge_manifest: true` option to enable nydus driver
to merge OCIv1 manifest and nydus manifest into a manifest
index in the target image, it's used for containerd to support
running OCIv1 image or nydus image simultaneously with a
single image reference.

Close https://github.com/goharbor/acceleration-service/issues/18

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>