### PR TITLE
Converter: adding annotations to track converted image

### DIFF
--- a/misc/config/config.yaml.estargz.tmpl
+++ b/misc/config/config.yaml.estargz.tmpl
@@ -34,6 +34,8 @@ provider:
 converter:
   # number of worker for executing conversion task
   worker: 5
+  # enable to add harbor specified annotations to converted image for tracking.
+  harbor_annotation: true
   driver:
     # accelerator driver type: `estargz`
     type: estargz

--- a/misc/config/config.yaml.nydus.tmpl
+++ b/misc/config/config.yaml.nydus.tmpl
@@ -34,6 +34,8 @@ provider:
 converter:
   # number of worker for executing conversion task
   worker: 5
+  # enable to add harbor specified annotations to converted image for tracking.
+  harbor_annotation: true
   driver:
     # accelerator driver type: `nydus`
     type: nydus

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,9 +65,10 @@ type ConversionRule struct {
 }
 
 type ConverterConfig struct {
-	Worker int              `yaml:"worker"`
-	Driver DriverConfig     `yaml:"driver"`
-	Rules  []ConversionRule `yaml:"rules"`
+	Worker           int              `yaml:"worker"`
+	Driver           DriverConfig     `yaml:"driver"`
+	HarborAnnotation bool             `yaml:"harbor_annotation"`
+	Rules            []ConversionRule `yaml:"rules"`
 }
 
 type DriverConfig struct {

--- a/pkg/converter/annotation/annotation.go
+++ b/pkg/converter/annotation/annotation.go
@@ -1,0 +1,147 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package annotation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+
+	providerContent "github.com/goharbor/acceleration-service/pkg/content"
+)
+
+type Appended struct {
+	DriverName    string
+	DriverVersion string
+	SourceDigest  string
+}
+
+const (
+	// The name annotation is used to identify different accelerated image formats in harbor.
+	// Example value: `nydus`, `estargz`.
+	AnnotationAccelerationDriverName = "io.goharbor.artifact.v1alpha1.acceleration.driver.name"
+	// The version annotation is used to identify different accelerated image format versions
+	// with same driver in harbor.
+	AnnotationAccelerationDriverVersion = "io.goharbor.artifact.v1alpha1.acceleration.driver.version"
+	// The digest annotation is used to reference the source (original) image, which can be
+	// used to avoid duplicate conversion or track the relationship between the source image
+	// and converted image in harbor.
+	// Example value: `sha256:2d64e20e048640ecb619b82a26c168b7649a173d4ad6cf2af3feda9b64fe6fb8`.
+	AnnotationAccelerationSourceDigest = "io.goharbor.artifact.v1alpha1.acceleration.source.digest"
+)
+
+// Ported from containerd project, copyright The containerd Authors.
+// https://github.com/containerd/containerd/blob/26d356d09de89b609cb75562fd87da6aa3c70740/images/converter/default.go#L385
+func readJSON(ctx context.Context, cs content.Store, x interface{}, desc ocispec.Descriptor) (map[string]string, error) {
+	info, err := cs.Info(ctx, desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := info.Labels
+	b, err := content.ReadBlob(ctx, cs, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(b, x); err != nil {
+		return nil, err
+	}
+
+	return labels, nil
+}
+
+// Modified from containerd project, copyright The containerd Authors.
+// https://github.com/containerd/containerd/blob/26d356d09de89b609cb75562fd87da6aa3c70740/images/converter/default.go#L401
+func writeJSON(ctx context.Context, cs content.Store, x interface{}, oldDesc ocispec.Descriptor, labels map[string]string) (*ocispec.Descriptor, error) {
+	b, err := json.MarshalIndent(x, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	dgst := digest.SHA256.FromBytes(b)
+
+	newDesc := oldDesc
+	newDesc.Size = int64(len(b))
+	newDesc.Digest = dgst
+
+	if err := content.WriteBlob(ctx, cs, dgst.String(), bytes.NewReader(b), newDesc, content.WithLabels(labels)); err != nil {
+		return nil, err
+	}
+
+	return &newDesc, nil
+}
+
+func annotate(annotations map[string]string, appended Appended) map[string]string {
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[AnnotationAccelerationDriverName] = appended.DriverName
+	if appended.DriverVersion != "" {
+		annotations[AnnotationAccelerationDriverVersion] = appended.DriverVersion
+	}
+	annotations[AnnotationAccelerationSourceDigest] = appended.SourceDigest
+
+	return annotations
+}
+
+func Append(ctx context.Context, provider providerContent.Provider, desc *ocispec.Descriptor, appended Appended) (*ocispec.Descriptor, error) {
+	var labels map[string]string
+	var err error
+
+	switch desc.MediaType {
+	case ocispec.MediaTypeImageManifest:
+		var manifest ocispec.Manifest
+		labels, err = readJSON(ctx, provider.ContentStore(), &manifest, *desc)
+		if err != nil {
+			return nil, errors.Wrap(err, "read manifest")
+		}
+
+		manifest.Annotations = annotate(manifest.Annotations, appended)
+		desc, err := writeJSON(ctx, provider.ContentStore(), manifest, *desc, labels)
+		if err != nil {
+			return nil, errors.Wrap(err, "write manifest")
+		}
+
+		return desc, nil
+
+	case ocispec.MediaTypeImageIndex:
+		var index ocispec.Index
+		labels, err = readJSON(ctx, provider.ContentStore(), &index, *desc)
+		if err != nil {
+			return nil, errors.Wrap(err, "read manifest index")
+		}
+
+		index.Annotations = annotate(index.Annotations, appended)
+		desc, err := writeJSON(ctx, provider.ContentStore(), index, *desc, labels)
+		if err != nil {
+			return nil, errors.Wrap(err, "write manifest index")
+		}
+
+		return desc, nil
+
+	case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema2ManifestList:
+		return nil, fmt.Errorf("docker manifest not support to append annotation")
+	}
+
+	return nil, fmt.Errorf("invalid mediatype %s", desc.MediaType)
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -35,6 +35,14 @@ type Driver interface {
 	// converted image manifest will be returned, otherwise a
 	// non-nil error will be returned.
 	Convert(context.Context, content.Provider) (*ocispec.Descriptor, error)
+
+	// Name gets the driver type name, it is used to identify
+	// different accelerated image formats.
+	Name() string
+
+	// Version gets the driver version, it is used to identify
+	// different accelerated image format versions with same driver.
+	Version() string
 }
 
 func NewLocalDriver(cfg *config.DriverConfig) (Driver, error) {

--- a/pkg/driver/estargz/estargz.go
+++ b/pkg/driver/estargz/estargz.go
@@ -45,6 +45,14 @@ func (d *Driver) Convert(ctx context.Context, p content.Provider) (*ocispec.Desc
 		ctx, p.ContentStore(), p.Image().Target())
 }
 
+func (d *Driver) Name() string {
+	return "estargz"
+}
+
+func (d *Driver) Version() string {
+	return ""
+}
+
 func getESGZConvertOpts(cfg map[string]string) (opts []estargz.Option, docker2oci bool, err error) {
 	if s, ok := cfg["docker2oci"]; ok {
 		b, err := strconv.ParseBool(s)

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -46,6 +46,7 @@ type Driver struct {
 	backend       backend.Backend
 	packer        *packer.Packer
 	mergeManifest bool
+	rafsVersion   string
 }
 
 func New(cfg map[string]string) (*Driver, error) {
@@ -81,6 +82,9 @@ func New(cfg map[string]string) (*Driver, error) {
 	}
 
 	rafsVersion := cfg["rafs_version"]
+	if rafsVersion == "" {
+		rafsVersion = "5"
+	}
 
 	p, err := packer.New(packer.Option{
 		WorkDir:     workDir,
@@ -95,6 +99,7 @@ func New(cfg map[string]string) (*Driver, error) {
 		packer:        p,
 		backend:       _backend,
 		mergeManifest: mergeManifest,
+		rafsVersion:   rafsVersion,
 	}, nil
 }
 
@@ -237,4 +242,12 @@ func (nydus *Driver) Convert(ctx context.Context, content content.Provider) (*oc
 	}
 
 	return nydus.makeManifestIndex(ctx, content, targetDescs)
+}
+
+func (nydus *Driver) Name() string {
+	return "nydus"
+}
+
+func (nydus *Driver) Version() string {
+	return nydus.rafsVersion
 }

--- a/pkg/driver/nydus/packer/packer.go
+++ b/pkg/driver/nydus/packer/packer.go
@@ -53,10 +53,6 @@ type Option struct {
 }
 
 func New(option Option) (*Packer, error) {
-	if option.RafsVersion == "" {
-		option.RafsVersion = "5"
-	}
-
 	return &Packer{
 		parentWorkDir: option.WorkDir,
 		builderPath:   option.BuilderPath,


### PR DESCRIPTION
Add option `harbor_annotation: true` to append harbor specified annotations
to the manifest of converted image:

```
{
  ...
  annotation：{
    "io.goharbor.artifact.v1alpha1.acceleration.type": "estargz"
    "io.goharbor.artifact.v1alpha1.acceleration.source.digest": "sha256:dbad66bcfe29ef383157a3e122acbd08cd2ebd40f5658afa2ae62c52ffe26e9f"
  }
}
```

The first annotation is used to identify different accelerated image
formats in harbor.

The second annotation is used to reference the source (original) image,
which can be used to avoid duplicate conversion or track the relationship
between the source image and converted image in harbor portal.

Close https://github.com/goharbor/acceleration-service/issues/3

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>