### PR TITLE
Nydus: support importing chunk dict

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Test Nydus Driver
       run: |
-        NYDUS_VERSION=2.0.0-rc.0
+        NYDUS_VERSION=2.0.0-rc.1
 
         # Download nydus components
         wget https://github.com/dragonflyoss/image-service/releases/download/v$NYDUS_VERSION/nydus-static-v$NYDUS_VERSION-x86_64.tgz

--- a/misc/config/config.yaml.nydus.tmpl
+++ b/misc/config/config.yaml.nydus.tmpl
@@ -42,13 +42,15 @@ converter:
     config:
       work_dir: /tmp
       # `nydus-image` binary path, download it from:
-      # https://github.com/dragonflyoss/image-service/releases (require v2.0.0 or higher)
+      # https://github.com/dragonflyoss/image-service/releases (require v2.0.0-rc.1 or higher)
       builder: nydus-image
       # specify nydus format version, possible values: `5`, `6` (EROFS-compatible), default is `5`
       rafs_version: 5
       # ensure that both OCIv1 manifest and nydus manifest are present as manifest index in the target image.
       # it's used for containerd to support running OCIv1 image or nydus image simultaneously with a single image reference.
       merge_manifest: false
+      # nydus chunk dict image reference, used for chunk-leveled data deduplication.
+      # chunk_dict_ref: localhost/chunk_dict/image:latest
       # specify a storage backend for storing nydus blob, optional, possible values: oss, localfs
       # backend_type: oss
       # backend_config: '{"endpoint":"","access_key_id":"","access_key_secret":"","bucket_name":""}'

--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -55,6 +55,8 @@ type Provider interface {
 	Snapshotter() snapshots.Snapshotter
 	// ContentStore gets the content store object of containerd.
 	ContentStore() content.Store
+	// Client gets the raw containerd client.
+	Client() *containerd.Client
 }
 
 type LocalProvider struct {
@@ -144,4 +146,8 @@ func (pvd *LocalProvider) Snapshotter() snapshots.Snapshotter {
 
 func (pvd *LocalProvider) ContentStore() content.Store {
 	return pvd.client.ContentStore()
+}
+
+func (pvd *LocalProvider) Client() *containerd.Client {
+	return pvd.client
 }

--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -39,6 +39,8 @@ var logger = logrus.WithField("module", "content")
 // Provider provides necessary image utils, image content
 // store for image conversion.
 type Provider interface {
+	// Resolve attempts to resolve the reference into a name and descriptor.
+	Resolver(ctx context.Context, ref string) (remotes.Resolver, error)
 	// Pull pulls source image from remote registry by specified reference.
 	// This pulls all platforms of the image but Image() returns containerd.Image for
 	// the default platoform.
@@ -72,7 +74,7 @@ func NewLocalProvider(
 	}, nil
 }
 
-func (pvd *LocalProvider) getResolver(ctx context.Context, ref string) (remotes.Resolver, error) {
+func (pvd *LocalProvider) Resolver(ctx context.Context, ref string) (remotes.Resolver, error) {
 	refURL, err := url.Parse(fmt.Sprintf("dummy://%s", ref))
 	if err != nil {
 		return nil, errors.Wrap(err, "parse reference of source image")
@@ -89,7 +91,7 @@ func (pvd *LocalProvider) getResolver(ctx context.Context, ref string) (remotes.
 }
 
 func (pvd *LocalProvider) Pull(ctx context.Context, ref string) error {
-	resolver, err := pvd.getResolver(ctx, ref)
+	resolver, err := pvd.Resolver(ctx, ref)
 	if err != nil {
 		return errors.Wrapf(err, "get resolver for %s", ref)
 	}
@@ -123,7 +125,7 @@ func (pvd *LocalProvider) Pull(ctx context.Context, ref string) error {
 }
 
 func (pvd *LocalProvider) Push(ctx context.Context, desc ocispec.Descriptor, ref string) error {
-	resolver, err := pvd.getResolver(ctx, ref)
+	resolver, err := pvd.Resolver(ctx, ref)
 	if err != nil {
 		return errors.Wrapf(err, "get resolver for %s", ref)
 	}

--- a/pkg/converter/annotation/annotation.go
+++ b/pkg/converter/annotation/annotation.go
@@ -15,18 +15,15 @@
 package annotation
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 
 	providerContent "github.com/goharbor/acceleration-service/pkg/content"
+	"github.com/goharbor/acceleration-service/pkg/utils"
 )
 
 type Appended struct {
@@ -49,47 +46,6 @@ const (
 	AnnotationAccelerationSourceDigest = "io.goharbor.artifact.v1alpha1.acceleration.source.digest"
 )
 
-// Ported from containerd project, copyright The containerd Authors.
-// https://github.com/containerd/containerd/blob/26d356d09de89b609cb75562fd87da6aa3c70740/images/converter/default.go#L385
-func readJSON(ctx context.Context, cs content.Store, x interface{}, desc ocispec.Descriptor) (map[string]string, error) {
-	info, err := cs.Info(ctx, desc.Digest)
-	if err != nil {
-		return nil, err
-	}
-
-	labels := info.Labels
-	b, err := content.ReadBlob(ctx, cs, desc)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(b, x); err != nil {
-		return nil, err
-	}
-
-	return labels, nil
-}
-
-// Modified from containerd project, copyright The containerd Authors.
-// https://github.com/containerd/containerd/blob/26d356d09de89b609cb75562fd87da6aa3c70740/images/converter/default.go#L401
-func writeJSON(ctx context.Context, cs content.Store, x interface{}, oldDesc ocispec.Descriptor, labels map[string]string) (*ocispec.Descriptor, error) {
-	b, err := json.MarshalIndent(x, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-	dgst := digest.SHA256.FromBytes(b)
-
-	newDesc := oldDesc
-	newDesc.Size = int64(len(b))
-	newDesc.Digest = dgst
-
-	if err := content.WriteBlob(ctx, cs, dgst.String(), bytes.NewReader(b), newDesc, content.WithLabels(labels)); err != nil {
-		return nil, err
-	}
-
-	return &newDesc, nil
-}
-
 func annotate(annotations map[string]string, appended Appended) map[string]string {
 	if annotations == nil {
 		annotations = make(map[string]string)
@@ -111,13 +67,13 @@ func Append(ctx context.Context, provider providerContent.Provider, desc *ocispe
 	switch desc.MediaType {
 	case ocispec.MediaTypeImageManifest:
 		var manifest ocispec.Manifest
-		labels, err = readJSON(ctx, provider.ContentStore(), &manifest, *desc)
+		labels, err = utils.ReadJSON(ctx, provider.ContentStore(), &manifest, *desc)
 		if err != nil {
 			return nil, errors.Wrap(err, "read manifest")
 		}
 
 		manifest.Annotations = annotate(manifest.Annotations, appended)
-		desc, err := writeJSON(ctx, provider.ContentStore(), manifest, *desc, labels)
+		desc, err := utils.WriteJSON(ctx, provider.ContentStore(), manifest, *desc, "", labels)
 		if err != nil {
 			return nil, errors.Wrap(err, "write manifest")
 		}
@@ -126,13 +82,13 @@ func Append(ctx context.Context, provider providerContent.Provider, desc *ocispe
 
 	case ocispec.MediaTypeImageIndex:
 		var index ocispec.Index
-		labels, err = readJSON(ctx, provider.ContentStore(), &index, *desc)
+		labels, err = utils.ReadJSON(ctx, provider.ContentStore(), &index, *desc)
 		if err != nil {
 			return nil, errors.Wrap(err, "read manifest index")
 		}
 
 		index.Annotations = annotate(index.Annotations, appended)
-		desc, err := writeJSON(ctx, provider.ContentStore(), index, *desc, labels)
+		desc, err := utils.WriteJSON(ctx, provider.ContentStore(), index, *desc, "", labels)
 		if err != nil {
 			return nil, errors.Wrap(err, "write manifest index")
 		}

--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -89,7 +89,7 @@ func NewLocalConverter(cfg *config.Config) (*LocalConverter, error) {
 func (cvt *LocalConverter) Convert(ctx context.Context, source string) error {
 	ctx, done, err := cvt.client.WithLease(ctx)
 	if err != nil {
-		return errors.Wrap(err, "create containerd lease")
+		return errors.Wrap(err, "create lease")
 	}
 	defer done(ctx)
 

--- a/pkg/driver/nydus/builder/builder.go
+++ b/pkg/driver/nydus/builder/builder.go
@@ -52,10 +52,14 @@ type Blob struct {
 	BlobSize int    `json:"blob_size"`
 }
 
+type Artifact struct {
+	BootstrapName string `json:"bootstrap_name"`
+	Blobs         []Blob `json:"blobs"`
+}
+
 type Output struct {
-	Version      string   `json:"version"`
-	OrderedBlobs []*Blob  `json:"ordered_blobs"`
-	Bootstraps   []string `json:"bootstraps"`
+	Version   string     `json:"version"`
+	Artifacts []Artifact `json:"artifacts"`
 }
 
 func New(builderPath string) *Builder {

--- a/pkg/driver/nydus/builder/builder.go
+++ b/pkg/driver/nydus/builder/builder.go
@@ -16,6 +16,7 @@ package builder
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os/exec"
@@ -29,6 +30,7 @@ var logger = logrus.WithField("module", "builder")
 
 type Option struct {
 	ParentBootstrapPath *string
+	ChunkDictPath       *string
 	BootstrapDirPath    string
 	BlobDirPath         string
 
@@ -100,6 +102,9 @@ func (builder *Builder) Run(option Option) (*Output, error) {
 	}
 	if option.ParentBootstrapPath != nil {
 		args = append(args, "--parent-bootstrap", *option.ParentBootstrapPath)
+	}
+	if option.ChunkDictPath != nil {
+		args = append(args, "--chunk-dict", fmt.Sprintf("bootstrap=%s", *option.ChunkDictPath))
 	}
 
 	logrus.Debugf("\tCommand: %s %s", builder.builderPath, strings.Join(args[:], " "))

--- a/pkg/driver/nydus/export/export.go
+++ b/pkg/driver/nydus/export/export.go
@@ -105,11 +105,9 @@ func Export(ctx context.Context, content content.Provider, layers []packer.Descr
 
 	labels := map[string]string{}
 	labels["containerd.io/gc.ref.content.0"] = nydusConfigDesc.Digest.String()
-
-	for idx, blobDesc := range finalLayer.Blobs {
-		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", idx+1)] = blobDesc.Digest.String()
+	for idx, desc := range descs {
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", idx+1)] = desc.Digest.String()
 	}
-	labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", len(finalLayer.Blobs)+1)] = finalLayer.Bootstrap.Digest.String()
 
 	if err := imageContent.WriteBlob(
 		ctx, content.ContentStore(), nydusManifestDesc.Digest.String(), bytes.NewReader(manifestBytes), *nydusManifestDesc, imageContent.WithLabels(labels),

--- a/pkg/driver/nydus/layer.go
+++ b/pkg/driver/nydus/layer.go
@@ -27,7 +27,6 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/acceleration-service/pkg/driver/nydus/backend"
-	"github.com/goharbor/acceleration-service/pkg/driver/nydus/packer"
 )
 
 type buildLayer struct {
@@ -82,12 +81,12 @@ func (layer *buildLayer) ContentStore(ctx context.Context) imageContent.Store {
 	return layer.cs
 }
 
-func (layer *buildLayer) GetCache(ctx context.Context, compressionType packer.CompressionType) (*ocispec.Descriptor, error) {
+func (layer *buildLayer) GetCache(ctx context.Context) (bootstrapDesc *ocispec.Descriptor, blobDescs []ocispec.Descriptor, err error) {
 	// TODO: get cache from local storage.
-	return nil, errdefs.ErrNotFound
+	return nil, nil, errdefs.ErrNotFound
 }
 
-func (layer *buildLayer) SetCache(ctx context.Context, compressionType packer.CompressionType, desc *ocispec.Descriptor) error {
+func (layer *buildLayer) SetCache(ctx context.Context, bootstrapDesc ocispec.Descriptor, blobDescs []ocispec.Descriptor) error {
 	// TODO: set cache to local storage.
 	return nil
 }

--- a/pkg/driver/nydus/packer/layer.go
+++ b/pkg/driver/nydus/packer/layer.go
@@ -45,17 +45,14 @@ type Layer interface {
 	// Mount mounts layer by snapshotter, release func provides a unmount operation.
 	Mount(ctx context.Context) (mounts []mount.Mount, release func() error, err error)
 
-	// SetCache records nydus bootstrap/blob descriptor to cache, desc == nil if
-	// nydus blob content is empty.
-	SetCache(ctx context.Context, compressionType CompressionType, desc *ocispec.Descriptor) error
+	// SetCache records nydus bootstrap and blob descriptors to cache.
+	SetCache(ctx context.Context, bootstrapDesc ocispec.Descriptor, blobDescs []ocispec.Descriptor) error
 
-	// GetCache get nydus bootstrap/blob descriptor from cache, following situations
+	// GetCache get nydus bootstrap and blob descriptors from cache, following situations
 	// should be handled:
 	// err != nil, cache miss;
-	// err == nil:
-	//   - desc == nil, cache hits, but nydus blob content is empty;
-	//   - desc != nil, cache hits;
-	GetCache(ctx context.Context, compressionType CompressionType) (desc *ocispec.Descriptor, err error)
+	// err == nil, cache hits;
+	GetCache(ctx context.Context) (bootstrapDesc *ocispec.Descriptor, blobDescs []ocispec.Descriptor, err error)
 
 	// Backend provides a storage for storing nydus blob, for example oss object storage.
 	Backend(ctx context.Context) backend.Backend

--- a/pkg/driver/nydus/packer/layer.go
+++ b/pkg/driver/nydus/packer/layer.go
@@ -196,7 +196,7 @@ func (layer *BuildLayer) exportBootstrap(ctx context.Context, sg *singleflight.G
 		bootstrapPath, utils.BootstrapFileNameInLayer, true,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "calculate compressed boostrap digest")
+		return nil, errors.Wrap(err, "calculate compressed bootstrap digest")
 	}
 
 	_desc, err, _ := sg.Do(compressedDigest.String(), func() (interface{}, error) {
@@ -204,7 +204,7 @@ func (layer *BuildLayer) exportBootstrap(ctx context.Context, sg *singleflight.G
 			bootstrapPath, utils.BootstrapFileNameInLayer, false,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, "calculate uncompressed boostrap digest")
+			return nil, errors.Wrap(err, "calculate uncompressed bootstrap digest")
 		}
 
 		desc := ocispec.Descriptor{

--- a/pkg/driver/nydus/parser/parser.go
+++ b/pkg/driver/nydus/parser/parser.go
@@ -1,0 +1,177 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	imageContent "github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/remotes"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/goharbor/acceleration-service/pkg/content"
+	"github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+)
+
+var logger = logrus.WithField("module", "nydus-driver")
+
+type Parser struct {
+	content content.Provider
+}
+
+func New(content content.Provider) (*Parser, error) {
+	return &Parser{
+		content: content,
+	}, nil
+}
+
+func fetch(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor, target interface{}) error {
+	rc, err := fetcher.Fetch(ctx, desc)
+	if err != nil {
+		return errors.Wrapf(err, "fetch %s", desc.Digest)
+	}
+	defer rc.Close()
+
+	bytes, err := ioutil.ReadAll(rc)
+	if err != nil {
+		return errors.Wrapf(err, "read manifest")
+	}
+
+	if err := json.Unmarshal(bytes, target); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (parser *Parser) pull(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor) error {
+	rc, err := fetcher.Fetch(ctx, desc)
+	if err != nil {
+		return errors.Wrapf(err, "fetch blob %s", desc.Digest)
+	}
+	defer rc.Close()
+
+	cw, err := imageContent.OpenWriter(
+		ctx, parser.content.ContentStore(),
+		imageContent.WithRef(remotes.MakeRefKey(ctx, desc)),
+		imageContent.WithDescriptor(desc),
+	)
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "open writer")
+	}
+	defer cw.Close()
+
+	if err := imageContent.Copy(ctx, cw, rc, desc.Size, desc.Digest); err != nil {
+		return errors.Wrapf(err, "pull blob to content store")
+	}
+
+	return nil
+}
+
+func (parser *Parser) findNydusManifest(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor) (*ocispec.Manifest, error) {
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		var manifest ocispec.Manifest
+		if err := fetch(ctx, fetcher, desc, &manifest); err != nil {
+			return nil, errors.Wrap(err, "fetch manifest")
+		}
+
+		if utils.IsNydusManifest(&manifest) {
+			return &manifest, nil
+		}
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		var index ocispec.Index
+		if err := fetch(ctx, fetcher, desc, &index); err != nil {
+			return nil, errors.Wrap(err, "fetch manifest index")
+		}
+
+		for _, desc := range index.Manifests {
+			if utils.IsNydusPlatform(desc.Platform) {
+				return parser.findNydusManifest(ctx, fetcher, desc)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("not found nydus manifest")
+}
+
+func (parser *Parser) PullAsChunkDict(ctx context.Context, ref string) (imageContent.ReaderAt, map[string]ocispec.Descriptor, error) {
+	resolver, err := parser.content.Resolver(ctx, ref)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "get resolver for %s", ref)
+	}
+
+	_, desc, err := resolver.Resolve(ctx, ref)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "resolve reference %s", ref)
+	}
+
+	fetcher, err := resolver.Fetcher(ctx, ref)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "get fetcher for %s", ref)
+	}
+
+	manifest, err := parser.findNydusManifest(ctx, fetcher, desc)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	logger.Infof("pulling chunk dict image %s", ref)
+	var bootstrapDesc *ocispec.Descriptor
+	blobs := make(map[string]ocispec.Descriptor)
+	eg := errgroup.Group{}
+	for idx := range manifest.Layers {
+		layer := manifest.Layers[idx]
+		if layer.Annotations == nil {
+			continue
+		}
+		eg.Go(func(desc ocispec.Descriptor) func() error {
+			return func() error {
+				return errors.Wrapf(parser.pull(ctx, fetcher, desc), "pull chunk dict image layer %s", desc.Digest)
+			}
+		}(layer))
+		if layer.Annotations[utils.LayerAnnotationNydusBootstrap] != "" {
+			bootstrapDesc = &layer
+		} else if layer.Annotations[utils.LayerAnnotationNydusBlob] != "" {
+			blobs[layer.Digest.Hex()] = layer
+		}
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, nil, err
+	}
+	logger.Infof("pulled chunk dict image %s", ref)
+
+	if bootstrapDesc == nil {
+		return nil, nil, errors.Errorf("invalid nydus manifest")
+	}
+
+	ra, err := parser.content.ContentStore().ReaderAt(ctx, *bootstrapDesc)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "fetch bootstrap %s", bootstrapDesc.Digest)
+	}
+
+	return ra, blobs, nil
+}

--- a/pkg/driver/nydus/parser/parser.go
+++ b/pkg/driver/nydus/parser/parser.go
@@ -16,21 +16,17 @@ package parser
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
 
+	"github.com/containerd/containerd"
 	imageContent "github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/goharbor/acceleration-service/pkg/content"
-	"github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+	nydusUtils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+	"github.com/goharbor/acceleration-service/pkg/utils"
 )
 
 var logger = logrus.WithField("module", "nydus-driver")
@@ -45,130 +41,50 @@ func New(content content.Provider) (*Parser, error) {
 	}, nil
 }
 
-func fetch(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor, target interface{}) error {
-	rc, err := fetcher.Fetch(ctx, desc)
-	if err != nil {
-		return errors.Wrapf(err, "fetch %s", desc.Digest)
-	}
-	defer rc.Close()
-
-	bytes, err := ioutil.ReadAll(rc)
-	if err != nil {
-		return errors.Wrapf(err, "read manifest")
-	}
-
-	if err := json.Unmarshal(bytes, target); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (parser *Parser) pull(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor) error {
-	rc, err := fetcher.Fetch(ctx, desc)
-	if err != nil {
-		return errors.Wrapf(err, "fetch blob %s", desc.Digest)
-	}
-	defer rc.Close()
-
-	cw, err := imageContent.OpenWriter(
-		ctx, parser.content.ContentStore(),
-		imageContent.WithRef(remotes.MakeRefKey(ctx, desc)),
-		imageContent.WithDescriptor(desc),
-	)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			return nil
-		}
-		return errors.Wrapf(err, "open writer")
-	}
-	defer cw.Close()
-
-	if err := imageContent.Copy(ctx, cw, rc, desc.Size, desc.Digest); err != nil {
-		return errors.Wrapf(err, "pull blob to content store")
-	}
-
-	return nil
-}
-
-func (parser *Parser) findNydusManifest(ctx context.Context, fetcher remotes.Fetcher, desc ocispec.Descriptor) (*ocispec.Manifest, error) {
-	switch desc.MediaType {
-	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
-		var manifest ocispec.Manifest
-		if err := fetch(ctx, fetcher, desc, &manifest); err != nil {
-			return nil, errors.Wrap(err, "fetch manifest")
-		}
-
-		if utils.IsNydusManifest(&manifest) {
-			return &manifest, nil
-		}
-	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
-		var index ocispec.Index
-		if err := fetch(ctx, fetcher, desc, &index); err != nil {
-			return nil, errors.Wrap(err, "fetch manifest index")
-		}
-
-		for _, desc := range index.Manifests {
-			if utils.IsNydusPlatform(desc.Platform) {
-				return parser.findNydusManifest(ctx, fetcher, desc)
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("not found nydus manifest")
-}
-
 func (parser *Parser) PullAsChunkDict(ctx context.Context, ref string) (imageContent.ReaderAt, map[string]ocispec.Descriptor, error) {
+	cs := parser.content.ContentStore()
+
 	resolver, err := parser.content.Resolver(ctx, ref)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "get resolver for %s", ref)
 	}
-
-	_, desc, err := resolver.Resolve(ctx, ref)
+	opts := []containerd.RemoteOpt{
+		containerd.WithPlatformMatcher(nydusUtils.NydusPlatformComparer{}),
+		containerd.WithImageHandler(images.HandlerFunc(
+			func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				if images.IsLayerType(desc.MediaType) {
+					logger.Debugf("pulling chunk dict image layer %s", desc.Digest)
+				}
+				return nil, nil
+			},
+		)),
+		containerd.WithResolver(resolver),
+	}
+	image, err := parser.content.Client().Fetch(ctx, ref, opts...)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "resolve reference %s", ref)
+		return nil, nil, errors.Wrapf(err, "pull chunk dict image %s", ref)
 	}
 
-	fetcher, err := resolver.Fetcher(ctx, ref)
+	manifest := ocispec.Manifest{}
+	_, err = utils.ReadJSON(ctx, cs, &manifest, image.Target)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "get fetcher for %s", ref)
+		return nil, nil, errors.Wrap(err, "read manifest json")
 	}
 
-	manifest, err := parser.findNydusManifest(ctx, fetcher, desc)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	logger.Infof("pulling chunk dict image %s", ref)
 	var bootstrapDesc *ocispec.Descriptor
 	blobs := make(map[string]ocispec.Descriptor)
-	eg := errgroup.Group{}
-	for idx := range manifest.Layers {
-		layer := manifest.Layers[idx]
-		if layer.Annotations == nil {
+	for _, desc := range manifest.Layers {
+		if desc.Annotations == nil {
 			continue
 		}
-		eg.Go(func(desc ocispec.Descriptor) func() error {
-			return func() error {
-				return errors.Wrapf(parser.pull(ctx, fetcher, desc), "pull chunk dict image layer %s", desc.Digest)
-			}
-		}(layer))
-		if layer.Annotations[utils.LayerAnnotationNydusBootstrap] != "" {
-			bootstrapDesc = &layer
-		} else if layer.Annotations[utils.LayerAnnotationNydusBlob] != "" {
-			blobs[layer.Digest.Hex()] = layer
+		if desc.Annotations[nydusUtils.LayerAnnotationNydusBootstrap] != "" {
+			bootstrapDesc = &desc
+		} else if desc.Annotations[nydusUtils.LayerAnnotationNydusBlob] != "" {
+			blobs[desc.Digest.Hex()] = desc
 		}
 	}
-	if err := eg.Wait(); err != nil {
-		return nil, nil, err
-	}
-	logger.Infof("pulled chunk dict image %s", ref)
 
-	if bootstrapDesc == nil {
-		return nil, nil, errors.Errorf("invalid nydus manifest")
-	}
-
-	ra, err := parser.content.ContentStore().ReaderAt(ctx, *bootstrapDesc)
+	ra, err := cs.ReaderAt(ctx, *bootstrapDesc)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "fetch bootstrap %s", bootstrapDesc.Digest)
 	}

--- a/pkg/driver/nydus/utils/utils.go
+++ b/pkg/driver/nydus/utils/utils.go
@@ -104,3 +104,20 @@ func (c ExcludeNydusPlatformComparer) Match(platform ocispec.Platform) bool {
 func (c ExcludeNydusPlatformComparer) Less(a, b ocispec.Platform) bool {
 	return c.MatchComparer.Less(a, b)
 }
+
+type NydusPlatformComparer struct {
+	platforms.MatchComparer
+}
+
+func (c NydusPlatformComparer) Match(platform ocispec.Platform) bool {
+	for _, key := range platform.OSFeatures {
+		if key == ManifestOSFeatureNydus {
+			return true
+		}
+	}
+	return false
+}
+
+func (c NydusPlatformComparer) Less(a, b ocispec.Platform) bool {
+	return c.MatchComparer.Less(a, b)
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	"github.com/containerd/containerd/content"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Ported from containerd project, copyright The containerd Authors.
+// https://github.com/containerd/containerd/blob/26d356d09de89b609cb75562fd87da6aa3c70740/images/converter/default.go#L385
+func ReadJSON(ctx context.Context, cs content.Store, x interface{}, desc ocispec.Descriptor) (map[string]string, error) {
+	info, err := cs.Info(ctx, desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := info.Labels
+	b, err := content.ReadBlob(ctx, cs, desc)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(b, x); err != nil {
+		return nil, err
+	}
+
+	return labels, nil
+}
+
+// Modified from containerd project, copyright The containerd Authors.
+// https://github.com/containerd/containerd/blob/26d356d09de89b609cb75562fd87da6aa3c70740/images/converter/default.go#L401
+func WriteJSON(ctx context.Context, cs content.Store, x interface{}, oldDesc ocispec.Descriptor, ref string, labels map[string]string) (*ocispec.Descriptor, error) {
+	b, err := json.MarshalIndent(x, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	dgst := digest.SHA256.FromBytes(b)
+
+	newDesc := oldDesc
+	newDesc.Size = int64(len(b))
+	newDesc.Digest = dgst
+
+	if ref == "" {
+		ref = dgst.String()
+	}
+
+	if err := content.WriteBlob(ctx, cs, ref, bytes.NewReader(b), newDesc, content.WithLabels(labels)); err != nil {
+		return nil, err
+	}
+
+	return &newDesc, nil
+}


### PR DESCRIPTION
```
Nydus uses a special chunk-dict image for chunk-leveled data
deduplication, the PR support importing the image during
image conversion.

It pulls nydus chunk-dict image from remote registry, writes all
layers into containerd content store, then provide chunk-dict
bootstrap to nydus-image.

Use `chunk_dict_ref` option in nydus driver configuration to
enable this feature.
```

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>