### PR TITLE
Nydus: fix move blob in localfs backend

### DIFF
--- a/pkg/driver/nydus/backend/backend.go
+++ b/pkg/driver/nydus/backend/backend.go
@@ -28,8 +28,10 @@ const (
 type Backend interface {
 	// Push pushes specified blob file to remote storage backend.
 	Push(ctx context.Context, blobPath string) error
-	// Check checks whether a blob exists in remote storage backend.
-	Check(blobID string) (bool, error)
+	// Check checks whether a blob exists in remote storage backend,
+	// blob exists -> return (blobPath, nil)
+	// blob not exists -> return ("", err)
+	Check(blobID string) (string, error)
 	// Type returns backend type name.
 	Type() string
 }

--- a/pkg/driver/nydus/backend/oss.go
+++ b/pkg/driver/nydus/backend/oss.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/aliyun/aliyun-oss-go-sdk/oss"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
@@ -160,9 +161,14 @@ func (b *OSSBackend) Push(ctx context.Context, blobPath string) error {
 	return nil
 }
 
-func (b *OSSBackend) Check(blobID string) (bool, error) {
+func (b *OSSBackend) Check(blobID string) (string, error) {
 	blobID = b.objectPrefix + blobID
-	return b.bucket.IsObjectExist(blobID)
+	if exist, err := b.bucket.IsObjectExist(blobID); err != nil {
+		return "", err
+	} else if exist {
+		return blobID, nil
+	}
+	return "", errdefs.ErrNotFound
 }
 
 func (b *OSSBackend) Type() string {


### PR DESCRIPTION
When enabling localfs backend, and have multiple same blobs output in diff build,
maybe acceld throws the following error:

```
export nydus blob: open blob ...: no such file or directory
```

The root cause is the blob be moved to localfs target directory in goroutine A,
then the goroutine B will fail in opening the blob file before moving.

Fix it by checking blob existence in backend before pushing to backend,
and the concurrent pushes are protected by singleflight.