### PR TITLE
Nydus: fix lost blob list in bootstrap layer

### DIFF
--- a/pkg/driver/nydus/export/export.go
+++ b/pkg/driver/nydus/export/export.go
@@ -58,19 +58,31 @@ func Export(ctx context.Context, content content.Provider, layers []packer.Descr
 	finalLayer := layers[len(layers)-1]
 
 	// Append blob layers.
-	if !hasBackend {
-		for _, blobDesc := range finalLayer.Blobs {
-			layerDiffID := digest.Digest(blobDesc.Annotations[utils.LayerAnnotationUncompressed])
-			nydusConfig.RootFS.DiffIDs = append(nydusConfig.RootFS.DiffIDs, layerDiffID)
-			delete(blobDesc.Annotations, utils.LayerAnnotationUncompressed)
-			descs = append(descs, blobDesc)
+	blobs := []string{}
+	for _, blobDesc := range finalLayer.Blobs {
+		blobs = append(blobs, blobDesc.Digest.Hex())
+		if hasBackend {
+			continue
 		}
+		descs = append(descs, blobDesc)
+		layerDiffID := digest.Digest(blobDesc.Annotations[utils.LayerAnnotationUncompressed])
+		nydusConfig.RootFS.DiffIDs = append(nydusConfig.RootFS.DiffIDs, layerDiffID)
+		// Remove unnecessary diff id annotation in final manifest.
+		delete(blobDesc.Annotations, utils.LayerAnnotationUncompressed)
 	}
 
 	// Append bootstrap layer.
 	layerDiffID := digest.Digest(finalLayer.Bootstrap.Annotations[utils.LayerAnnotationUncompressed])
 	nydusConfig.RootFS.DiffIDs = append(nydusConfig.RootFS.DiffIDs, layerDiffID)
+	// Remove unnecessary diff id annotation in final manifest.
 	delete(finalLayer.Bootstrap.Annotations, utils.LayerAnnotationUncompressed)
+
+	// Append blobs to the annotation of bootstrap layer.
+	blobBytes, err := json.Marshal(blobs)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal blob list")
+	}
+	finalLayer.Bootstrap.Annotations[utils.LayerAnnotationNydusBlobIDs] = string(blobBytes)
 	descs = append(descs, finalLayer.Bootstrap)
 
 	nydusConfigDesc, nydusConfigBytes, err := utils.MarshalToDesc(nydusConfig, ocispec.MediaTypeImageConfig)

--- a/pkg/driver/nydus/packer/packer.go
+++ b/pkg/driver/nydus/packer/packer.go
@@ -334,7 +334,11 @@ func (p *Packer) Build(ctx context.Context, chunkDict *ChunkDict, layers []Layer
 
 							desc := _desc.(*ocispec.Descriptor)
 							if desc == nil {
-								return nil
+								// Handle the case which backend is specified, just fill digest
+								// for the use on following workflow.
+								desc = &ocispec.Descriptor{
+									Digest: blobDigest,
+								}
 							}
 							descs[idx].Blobs[blobIdx] = *desc
 

--- a/pkg/driver/nydus/utils/constant.go
+++ b/pkg/driver/nydus/utils/constant.go
@@ -22,6 +22,7 @@ const (
 	LayerAnnotationNydusBlob        = "containerd.io/snapshot/nydus-blob"
 	LayerAnnotationNydusBootstrap   = "containerd.io/snapshot/nydus-bootstrap"
 	LayerAnnotationNydusRAFSVersion = "containerd.io/snapshot/nydus-rafs-version"
+	LayerAnnotationNydusBlobIDs     = "containerd.io/snapshot/nydus-blob-ids"
 
 	LayerAnnotationUncompressed = "containerd.io/uncompressed"
 )


### PR DESCRIPTION
We should append the blob list into the annotation of bootstrap
layer, this blob list is used to GC in nydus snapshotter.

In the future, this annotation should be deprecated, but now we
should keep compatibility for the current version of nydus snapshotter:

https://github.com/containerd/nydus-snapshotter/issues/5

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>