### PR TITLE
API: add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,22 @@ GET /api/v1/conversions
 | ------ | -------------------------------------------- |
 | 200    | Return task list                             |
 | 401    | Unauthorized, invalid `Authorization` header |
+
+### Check Healthy
+
+#### Request
+
+```
+GET /api/v1/health
+```
+
+#### Response
+
+```
+Ok
+```
+
+| Status | Description                 |
+| ------ | --------------------------- |
+| 200    | Accled service is healthy   |
+| 500    | Accled service is unhealthy |

--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrUnauthorized     = errors.New("ERR_UNAUTHORIZED")
 	ErrConvertFailed    = errors.New("ERR_CONVERT_FAILED")
 	ErrAlreadyConverted = errors.New("ERR_ALREADY_CONVERTED")
+	ErrUnhealthy        = errors.New("ERR_UNHEALTHY")
 )

--- a/pkg/router/health.go
+++ b/pkg/router/health.go
@@ -1,0 +1,34 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package router
+
+import (
+	"net/http"
+
+	"github.com/goharbor/acceleration-service/pkg/errdefs"
+	"github.com/goharbor/acceleration-service/pkg/server/util"
+	"github.com/labstack/echo/v4"
+)
+
+func (r *LocalRouter) CheckHealth(ctx echo.Context) error {
+	err := r.handler.CheckHealth(ctx.Request().Context())
+	if err != nil {
+		return util.ReplyError(
+			ctx, http.StatusInternalServerError, errdefs.ErrUnhealthy,
+			err.Error(),
+		)
+	}
+	return ctx.String(http.StatusOK, "Ok")
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -44,6 +44,7 @@ func NewLocalRouter(handler handler.Handler) Router {
 func (router *LocalRouter) Register(server *echo.Echo) error {
 	server.POST("/api/v1/conversions", router.CreateTask)
 	server.GET("/api/v1/conversions", router.ListTask)
+	server.GET("/api/v1/health", router.CheckHealth)
 
 	// Any unexpected endpoint will return an error.
 	server.Any("*", func(ctx echo.Context) error {


### PR DESCRIPTION
Provide a health check API `GET /api/v1/health` to harbor,
it checks the acceld service is healthy and can serve webhook
request from harbor.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>