### PR TITLE
nydus: fix empty diff id for the blob layer of chunk dict

### DIFF
--- a/pkg/driver/nydus/export/export.go
+++ b/pkg/driver/nydus/export/export.go
@@ -65,8 +65,7 @@ func Export(ctx context.Context, content content.Provider, layers []packer.Descr
 			continue
 		}
 		descs = append(descs, blobDesc)
-		layerDiffID := digest.Digest(blobDesc.Annotations[utils.LayerAnnotationUncompressed])
-		nydusConfig.RootFS.DiffIDs = append(nydusConfig.RootFS.DiffIDs, layerDiffID)
+		nydusConfig.RootFS.DiffIDs = append(nydusConfig.RootFS.DiffIDs, blobDesc.Digest)
 		// Remove unnecessary diff id annotation in final manifest.
 		delete(blobDesc.Annotations, utils.LayerAnnotationUncompressed)
 	}


### PR DESCRIPTION
When exporting the image, the chunk dict blob's diff id isn't correctly
handled, so the nydus snapshotter goes wrong when preparing layer,
leads to containerd raises error `failed to extract layer : failed to get
stream processor for application/vnd.oci.image.layer.nydus.blob.v1: no
processor for media-type: unknown`.

To fix this bug, due to the nydus blob digest is the same as diff id,
we use blobDesc.Digest as layer diff id directly.

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>