### PR TITLE
nydus: fix panic on using chunk dict

### DIFF
--- a/pkg/driver/nydus/merge.go
+++ b/pkg/driver/nydus/merge.go
@@ -58,9 +58,7 @@ func mergeNydusLayers(ctx context.Context, cs content.Store, descs []ocispecs.De
 	pr, pw := io.Pipe()
 	go func() {
 		defer pw.Close()
-		if err := nydusify.Merge(ctx, layers, pw, nydusify.MergeOption{
-			WithTar: true,
-		}); err != nil {
+		if err := nydusify.Merge(ctx, layers, pw, opt); err != nil {
 			pw.CloseWithError(errors.Wrapf(err, "merge nydus bootstrap"))
 		}
 	}()


### PR DESCRIPTION
The merge operation should be passed with chunk dict bootstrap
path, otherwise will panic with this error:

Error: invalid bootstrap, seems have multiple non-chunk-dict
blobs in this bootstrap

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>