### PR TITLE
makefile: build version tag into binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
+VERSION_TAG=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
-CWD := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 default: check build
 
 # Build binary to ./
 build:
-	go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" ./cmd/acceld
-	go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" ./cmd/accelctl
+	go build -ldflags '-X main.versionTag=${VERSION_TAG} -X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" ./cmd/acceld
+	go build -ldflags '-X main.versionTag=${VERSION_TAG} -X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" ./cmd/accelctl
 
 install-check-tools:
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.43.0

--- a/cmd/accelctl/main.go
+++ b/cmd/accelctl/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/goharbor/acceleration-service/pkg/handler"
 )
 
+var versionTag string
 var versionGitCommit string
 var versionBuildTime string
 
@@ -46,7 +47,8 @@ func main() {
 		TimestampFormat: time.RFC3339Nano,
 	})
 
-	version := fmt.Sprintf("%s.%s", versionGitCommit, versionBuildTime)
+	version := fmt.Sprintf("%s %s.%s", versionTag, versionGitCommit, versionBuildTime)
+	logrus.Infof("Version: %s\n", version)
 
 	app := &cli.App{
 		Name:    "accelctl",

--- a/cmd/acceld/main.go
+++ b/cmd/acceld/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/goharbor/acceleration-service/pkg/daemon"
 )
 
+var versionTag string
 var versionGitCommit string
 var versionBuildTime string
 
@@ -36,7 +37,7 @@ func main() {
 		TimestampFormat: time.RFC3339Nano,
 	})
 
-	version := fmt.Sprintf("%s.%s", versionGitCommit, versionBuildTime)
+	version := fmt.Sprintf("%s %s.%s", versionTag, versionGitCommit, versionBuildTime)
 	logrus.Infof("Version: %s\n", version)
 
 	app := &cli.App{


### PR DESCRIPTION
So that we can inspect the binary tag version using:

```
$ acceld --version
  acceld version v0.1.0
```

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>