### PR TITLE
converter: support skipping tls verification

### DIFF
--- a/misc/config/config.yaml.estargz.tmpl
+++ b/misc/config/config.yaml.estargz.tmpl
@@ -19,8 +19,8 @@ provider:
       # base64 encoded `<robot-name>:<robot-secret>` for robot
       # account created in harbor
       auth: YTpiCg==
-      # use http registry communication
-      insecure: true
+      # skip verifying server certs for HTTPS source registry
+      insecure: false
       webhook:
         # webhook request auth header configured in harbor
         auth_header: header

--- a/misc/config/config.yaml.nydus.tmpl
+++ b/misc/config/config.yaml.nydus.tmpl
@@ -19,8 +19,8 @@ provider:
       # base64 encoded `<robot-name>:<robot-secret>` for robot
       # account created in harbor
       auth: YTpiCg==
-      # use http registry communication
-      insecure: true
+      # skip verifying server certs for HTTPS source registry
+      insecure: false
       webhook:
         # webhook request auth header configured in harbor
         auth_header: header

--- a/pkg/driver/nydus/parser/parser.go
+++ b/pkg/driver/nydus/parser/parser.go
@@ -41,9 +41,12 @@ func New(content content.Provider) (*Parser, error) {
 	}, nil
 }
 
-func (parser *Parser) PullAsChunkDict(ctx context.Context, ref string) (imageContent.ReaderAt, map[string]ocispec.Descriptor, error) {
+func (parser *Parser) PullAsChunkDict(ctx context.Context, ref string, usePlainHTTP bool) (imageContent.ReaderAt, map[string]ocispec.Descriptor, error) {
 	cs := parser.content.ContentStore()
 
+	if usePlainHTTP {
+		parser.content.UsePlainHTTP()
+	}
 	resolver, err := parser.content.Resolver(ctx, ref)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "get resolver for %s", ref)

--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -8,6 +8,7 @@ package errdefs
 
 import (
 	"errors"
+	"strings"
 )
 
 var (
@@ -17,3 +18,23 @@ var (
 	ErrAlreadyConverted = errors.New("ERR_ALREADY_CONVERTED")
 	ErrUnhealthy        = errors.New("ERR_UNHEALTHY")
 )
+
+// IsErrHTTPResponseToHTTPSClient returns whether err is
+// "http: server gave HTTP response to HTTPS client"
+func isErrHTTPResponseToHTTPSClient(err error) bool {
+	// The error string is unexposed as of Go 1.16, so we can't use `errors.Is`.
+	// https://github.com/golang/go/issues/44855
+	const unexposed = "server gave HTTP response to HTTPS client"
+	return strings.Contains(err.Error(), unexposed)
+}
+
+// IsErrConnectionRefused return whether err is
+// "connect: connection refused"
+func isErrConnectionRefused(err error) bool {
+	const errMessage = "connect: connection refused"
+	return strings.Contains(err.Error(), errMessage)
+}
+
+func NeedsRetryWithHTTP(err error) bool {
+	return err != nil && (isErrHTTPResponseToHTTPSClient(err) || isErrConnectionRefused(err))
+}


### PR DESCRIPTION
```
An error is thrown when converting image to HTTPS registry with
self-signed TLS cert:

failed to do request: x509: certificate signed by unknown authority

We currently do not provide any option for the HTTPS registry to skip
insecure self-signed certificate verification, so this commit changes
the semantics of the previous `insecure: true` option to support it.
if users specify this option, then skips verifying HTTPS certs.

And this commit allows acceld automatically fallback to plain HTTP
if the first HTTPS request fails for an HTTP registry when whether
or not the `insecure: true` option is enabled.
```

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>