### PR TITLE
nydus: support more options

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -121,4 +121,4 @@ require (
 )
 
 // It will be updated to official repo once nydus-snapshotter release.
-replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.22
+replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.28

--- a/go.sum
+++ b/go.sum
@@ -889,8 +889,8 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imeoer/nydus-snapshotter v0.3.22 h1:Vg+dKVTmmiNGWCJ/4KMCYHIgAx3demSPXvxnBLv2UJ0=
-github.com/imeoer/nydus-snapshotter v0.3.22/go.mod h1:xRVCi0yITol7k6yzjGY1tdlYZZVy5Qn+7YVLDjZ+0AE=
+github.com/imeoer/nydus-snapshotter v0.3.28 h1:KYFEZoukvm7G70Jb+KaJoO6vS/D/ViHoLgmEH5d2f18=
+github.com/imeoer/nydus-snapshotter v0.3.28/go.mod h1:xRVCi0yITol7k6yzjGY1tdlYZZVy5Qn+7YVLDjZ+0AE=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/misc/config/config.estargz.yaml
+++ b/misc/config/config.estargz.yaml
@@ -36,6 +36,8 @@ converter:
   worker: 5
   # enable to add harbor specified annotations to converted image for tracking.
   harbor_annotation: true
+  # only convert images for specific platforms, leave empty for all platforms.
+  # platforms: linux/amd64,linux/arm64
   driver:
     # accelerator driver type: `estargz`
     type: estargz

--- a/misc/config/config.nydus.ref.yaml
+++ b/misc/config/config.nydus.ref.yaml
@@ -44,31 +44,10 @@ converter:
 
       # `nydus-image` binary path, download it from:
       # https://github.com/dragonflyoss/image-service/releases (require v2.0.0 or higher)
-      builder: nydus-image
+      # builder: nydus-image
 
       # convert to OCI-referenced nydus zran image.
       oci_ref: true
-
-      # specify nydus format version, possible values: `5`, `6` (EROFS-compatible), default is `6`
-      # fs_version: 6
-
-      # specify nydus blob compression algorithm, possible values: `none`, `lz4_block`, `gzip`, `zstd`, default is `zstd`
-      # compressor: zstd
-
-      # ensure that both OCIv1 manifest and nydus manifest are present as manifest index in the target image.
-      # it's used for containerd to support running OCIv1 image or nydus image simultaneously with a single image reference.
-      # note: please ensure that OCIv1 manifest already exists in target image reference.
-      # merge_manifest: true
-
-      # nydus chunk dict image reference, used for chunk-leveled data deduplication.
-      # chunk_dict_ref: localhost/chunk_dict/image:latest
-
-      # specify a storage backend for storing nydus blob, optional, possible values: oss, localfs
-      # backend_type: oss
-      # backend_config: '{"endpoint":"","access_key_id":"","access_key_secret":"","bucket_name":""}'
-
-      # backend_type: localfs
-      # backend_config: '{"dir":"/path/to/dir"}'
   rules:
     # add suffix to tag of source image reference as target image reference
     - tag_suffix: -nydus-oci-ref

--- a/misc/config/config.nydus.ref.yaml
+++ b/misc/config/config.nydus.ref.yaml
@@ -36,6 +36,8 @@ converter:
   worker: 5
   # enable to add harbor specified annotations to converted image for tracking.
   harbor_annotation: true
+  # only convert images for specific platforms, leave empty for all platforms.
+  # platforms: linux/amd64,linux/arm64
   driver:
     # accelerator driver type: `nydus`
     type: nydus

--- a/misc/config/config.nydus.yaml
+++ b/misc/config/config.nydus.yaml
@@ -36,6 +36,8 @@ converter:
   worker: 5
   # enable to add harbor specified annotations to converted image for tracking.
   harbor_annotation: true
+  # only convert images for specific platforms, leave empty for all platforms.
+  # platforms: linux/amd64,linux/arm64
   driver:
     # accelerator driver type: `nydus`
     type: nydus

--- a/misc/config/config.nydus.yaml
+++ b/misc/config/config.nydus.yaml
@@ -44,10 +44,10 @@ converter:
 
       # `nydus-image` binary path, download it from:
       # https://github.com/dragonflyoss/image-service/releases (require v2.0.0 or higher)
-      builder: nydus-image
+      # builder: nydus-image
 
       # convert to OCI-referenced nydus zran image.
-      oci_ref: false
+      # oci_ref: false
 
       # specify nydus format version, possible values: `5`, `6` (EROFS-compatible), default is `6`
       # fs_version: 6
@@ -63,12 +63,30 @@ converter:
       # nydus chunk dict image reference, used for chunk-leveled data deduplication.
       # chunk_dict_ref: localhost/chunk_dict/image:latest
 
-      # specify a storage backend for storing nydus blob, optional, possible values: oss, localfs
+      # enable to convert Docker media types into OCI ones.
+      # docker2oci: false
+
+      # enable to align uncompressed data chunks to 4K, only for fs version 5.
+      # fs_align_chunk: false
+
+      # set the size of data chunks, must be power of two and between 0x1000-0x1000000.
+      # fs_chunk_size: 0x100000
+
+      # file path pattern list (split by new line) want to prefetch.
+      # prefetch_patterns: /
+
+      # force to push blobs even if they already exist in storage backend.
+      # backend_force_push: false
+
+      # specify a storage backend for storing nydus blob, optional, possible values: oss, localfs, s3
       # backend_type: oss
       # backend_config: '{"endpoint":"","access_key_id":"","access_key_secret":"","bucket_name":""}'
 
       # backend_type: localfs
       # backend_config: '{"dir":"/path/to/dir"}'
+
+      # backend_type: s3
+      # backend_config: '{"scheme":"","endpoint":"","region":"","bucket_name":"","access_key_id":"","access_key_secret":"","object_prefix":""}'
   rules:
     # add suffix to tag of source image reference as target image reference
     - tag_suffix: -nydus

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -47,7 +47,7 @@ type LocalAdapter struct {
 	client *containerd.Client
 	rule   *Rule
 	worker *Worker
-	cvt    *converter.LocalConverter
+	cvt    *converter.Converter
 }
 
 func NewLocalAdapter(cfg *config.Config) (*LocalAdapter, error) {
@@ -64,7 +64,7 @@ func NewLocalAdapter(cfg *config.Config) (*LocalAdapter, error) {
 		return nil, errors.Wrap(err, "create content provider")
 	}
 
-	cvt, err := converter.NewLocalConverter(
+	cvt, err := converter.New(
 		converter.WithProvider(provider),
 		converter.WithDriver(cfg.Converter.Driver.Type, cfg.Converter.Driver.Config),
 	)

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -17,6 +17,7 @@ package adapter
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ import (
 	"github.com/goharbor/acceleration-service/pkg/converter"
 	"github.com/goharbor/acceleration-service/pkg/errdefs"
 	"github.com/goharbor/acceleration-service/pkg/metrics"
+	"github.com/goharbor/acceleration-service/pkg/platformutil"
 	"github.com/goharbor/acceleration-service/pkg/task"
 )
 
@@ -59,7 +61,13 @@ func NewLocalAdapter(cfg *config.Config) (*LocalAdapter, error) {
 		return nil, errors.Wrap(err, "create containerd client")
 	}
 
-	provider, err := content.NewLocalProvider(client, cfg.Host)
+	allPlatforms := len(strings.TrimSpace(cfg.Converter.Platforms)) == 0
+	platformMC, err := platformutil.ParsePlatforms(allPlatforms, cfg.Converter.Platforms)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid platform configuration")
+	}
+
+	provider, err := content.NewLocalProvider(client, cfg.Host, platformMC)
 	if err != nil {
 		return nil, errors.Wrap(err, "create content provider")
 	}
@@ -67,6 +75,7 @@ func NewLocalAdapter(cfg *config.Config) (*LocalAdapter, error) {
 	cvt, err := converter.New(
 		converter.WithProvider(provider),
 		converter.WithDriver(cfg.Converter.Driver.Type, cfg.Converter.Driver.Config),
+		converter.WithPlatform(platformMC),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,7 @@ type ConverterConfig struct {
 	Worker           int              `yaml:"worker"`
 	Driver           DriverConfig     `yaml:"driver"`
 	HarborAnnotation bool             `yaml:"harbor_annotation"`
+	Platforms        string           `yaml:"platforms"`
 	Rules            []ConversionRule `yaml:"rules"`
 }
 

--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -16,25 +16,11 @@ package content
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/labels"
-	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-
-	nydusUtils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
-	"github.com/goharbor/acceleration-service/pkg/remote"
-	"github.com/goharbor/acceleration-service/pkg/utils"
 )
-
-var logger = logrus.WithField("module", "content")
 
 // Provider provides necessary image utils, image content
 // store for image conversion.
@@ -56,141 +42,4 @@ type Provider interface {
 	Image(ctx context.Context, ref string) (*ocispec.Descriptor, error)
 	// ContentStore gets the content store object of containerd.
 	ContentStore() content.Store
-}
-
-type LocalProvider struct {
-	usePlainHTTP bool
-	client       *containerd.Client
-	hosts        remote.HostFunc
-}
-
-func NewLocalProvider(
-	client *containerd.Client,
-	hosts remote.HostFunc,
-) (Provider, error) {
-	return &LocalProvider{
-		client: client,
-		hosts:  hosts,
-	}, nil
-}
-
-func (pvd *LocalProvider) updateLayerDiffID(ctx context.Context, image ocispec.Descriptor) error {
-	cs := pvd.ContentStore()
-
-	maniDescs, err := utils.GetManifests(ctx, cs, image)
-	if err != nil {
-		return errors.Wrap(err, "get manifests")
-	}
-
-	for _, desc := range maniDescs {
-		bytes, err := content.ReadBlob(ctx, cs, desc)
-		if err != nil {
-			return errors.Wrap(err, "read manifest")
-		}
-
-		var manifest ocispec.Manifest
-		if err := json.Unmarshal(bytes, &manifest); err != nil {
-			return errors.Wrap(err, "unmarshal manifest")
-		}
-
-		diffIDs, err := images.RootFS(ctx, cs, manifest.Config)
-		if err != nil {
-			return errors.Wrap(err, "get diff ids from config")
-		}
-		if len(manifest.Layers) != len(diffIDs) {
-			return fmt.Errorf("unmatched layers between manifest and config: %d != %d", len(manifest.Layers), len(diffIDs))
-		}
-
-		for idx, diffID := range diffIDs {
-			layerDesc := manifest.Layers[idx]
-			info, err := cs.Info(ctx, layerDesc.Digest)
-			if err != nil {
-				return errors.Wrap(err, "get layer info")
-			}
-			if info.Labels == nil {
-				info.Labels = map[string]string{}
-			}
-			info.Labels[labels.LabelUncompressed] = diffID.String()
-			_, err = cs.Update(ctx, info)
-			if err != nil {
-				return errors.Wrap(err, "update layer label")
-			}
-		}
-	}
-
-	return nil
-}
-
-func (pvd *LocalProvider) UsePlainHTTP() {
-	pvd.usePlainHTTP = true
-}
-
-func (pvd *LocalProvider) Resolver(ref string) (remotes.Resolver, error) {
-	credFunc, insecure, err := pvd.hosts(ref)
-	if err != nil {
-		return nil, err
-	}
-	return remote.NewResolver(insecure, pvd.usePlainHTTP, credFunc), nil
-}
-
-func (pvd *LocalProvider) Pull(ctx context.Context, ref string) error {
-	resolver, err := pvd.Resolver(ref)
-	if err != nil {
-		return err
-	}
-
-	// TODO: enable configuring the target platforms.
-	platformMatcher := nydusUtils.ExcludeNydusPlatformComparer{MatchComparer: platforms.All}
-
-	opts := []containerd.RemoteOpt{
-		// TODO: sets max concurrent downloaded layer limit by containerd.WithMaxConcurrentDownloads.
-		containerd.WithPlatformMatcher(platformMatcher),
-		containerd.WithImageHandler(images.HandlerFunc(
-			func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
-				if images.IsLayerType(desc.MediaType) {
-					logger.Debugf("pulling layer %s", desc.Digest)
-				}
-				return nil, nil
-			},
-		)),
-		containerd.WithResolver(resolver),
-	}
-
-	// Pull the source image from remote registry.
-	image, err := pvd.client.Fetch(ctx, ref, opts...)
-	if err != nil {
-		return errors.Wrap(err, "pull source image")
-	}
-
-	// Write a diff id label of layer in content store for simplifying
-	// diff id calculation to speed up the conversion.
-	// See: https://github.com/containerd/containerd/blob/e4fefea5544d259177abb85b64e428702ac49c97/images/diffid.go#L49
-	if err := pvd.updateLayerDiffID(ctx, image.Target); err != nil {
-		return errors.Wrap(err, "update layer diff id")
-	}
-
-	return nil
-}
-
-func (pvd *LocalProvider) Push(ctx context.Context, desc ocispec.Descriptor, ref string) error {
-	resolver, err := pvd.Resolver(ref)
-	if err != nil {
-		return err
-	}
-
-	// TODO: sets max concurrent uploaded layer limit by containerd.WithMaxConcurrentUploadedLayers.
-	return pvd.client.Push(ctx, ref, desc, containerd.WithResolver(resolver))
-}
-
-func (pvd *LocalProvider) Image(ctx context.Context, ref string) (*ocispec.Descriptor, error) {
-	image, err := pvd.client.GetImage(ctx, ref)
-	if err != nil {
-		return nil, err
-	}
-	target := image.Target()
-	return &target, nil
-}
-
-func (pvd *LocalProvider) ContentStore() content.Store {
-	return pvd.client.ContentStore()
 }

--- a/pkg/content/local.go
+++ b/pkg/content/local.go
@@ -1,0 +1,115 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package content
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/remotes"
+	nydusUtils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+	"github.com/goharbor/acceleration-service/pkg/remote"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var logger = logrus.WithField("module", "content")
+
+type LocalProvider struct {
+	usePlainHTTP bool
+	client       *containerd.Client
+	hosts        remote.HostFunc
+}
+
+func NewLocalProvider(
+	client *containerd.Client,
+	hosts remote.HostFunc,
+) (Provider, error) {
+	return &LocalProvider{
+		client: client,
+		hosts:  hosts,
+	}, nil
+}
+
+func (pvd *LocalProvider) UsePlainHTTP() {
+	pvd.usePlainHTTP = true
+}
+
+func (pvd *LocalProvider) Resolver(ref string) (remotes.Resolver, error) {
+	credFunc, insecure, err := pvd.hosts(ref)
+	if err != nil {
+		return nil, err
+	}
+	return remote.NewResolver(insecure, pvd.usePlainHTTP, credFunc), nil
+}
+
+func (pvd *LocalProvider) Pull(ctx context.Context, ref string) error {
+	resolver, err := pvd.Resolver(ref)
+	if err != nil {
+		return err
+	}
+
+	// TODO: enable configuring the target platforms.
+	platformMatcher := nydusUtils.ExcludeNydusPlatformComparer{MatchComparer: platforms.All}
+
+	opts := []containerd.RemoteOpt{
+		// TODO: sets max concurrent downloaded layer limit by containerd.WithMaxConcurrentDownloads.
+		containerd.WithPlatformMatcher(platformMatcher),
+		containerd.WithImageHandler(images.HandlerFunc(
+			func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+				if images.IsLayerType(desc.MediaType) {
+					logger.Debugf("pulling layer %s", desc.Digest)
+				}
+				return nil, nil
+			},
+		)),
+		containerd.WithResolver(resolver),
+	}
+
+	// Pull the source image from remote registry.
+	_, err = pvd.client.Fetch(ctx, ref, opts...)
+	if err != nil {
+		return errors.Wrap(err, "pull source image")
+	}
+
+	return nil
+}
+
+func (pvd *LocalProvider) Push(ctx context.Context, desc ocispec.Descriptor, ref string) error {
+	resolver, err := pvd.Resolver(ref)
+	if err != nil {
+		return err
+	}
+
+	// TODO: sets max concurrent uploaded layer limit by containerd.WithMaxConcurrentUploadedLayers.
+	return pvd.client.Push(ctx, ref, desc, containerd.WithResolver(resolver))
+}
+
+func (pvd *LocalProvider) Image(ctx context.Context, ref string) (*ocispec.Descriptor, error) {
+	image, err := pvd.client.GetImage(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	target := image.Target()
+	return &target, nil
+}
+
+func (pvd *LocalProvider) ContentStore() content.Store {
+	return pvd.client.ContentStore()
+}

--- a/pkg/converter/opts.go
+++ b/pkg/converter/opts.go
@@ -15,6 +15,7 @@
 package converter
 
 import (
+	"github.com/containerd/containerd/platforms"
 	"github.com/goharbor/acceleration-service/pkg/content"
 )
 
@@ -22,6 +23,7 @@ type ConvertOpts struct {
 	provider     content.Provider
 	driverType   string
 	driverConfig map[string]string
+	platformMC   platforms.MatchComparer
 }
 
 type ConvertOpt func(opts *ConvertOpts) error
@@ -37,6 +39,13 @@ func WithDriver(typ string, config map[string]string) ConvertOpt {
 	return func(opts *ConvertOpts) error {
 		opts.driverType = typ
 		opts.driverConfig = config
+		return nil
+	}
+}
+
+func WithPlatform(platformMC platforms.MatchComparer) ConvertOpt {
+	return func(opts *ConvertOpts) error {
+		opts.platformMC = platformMC
 		return nil
 	}
 }

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/goharbor/acceleration-service/pkg/content"
@@ -45,12 +46,12 @@ type Driver interface {
 	Version() string
 }
 
-func NewLocalDriver(typ string, config map[string]string) (Driver, error) {
+func NewLocalDriver(typ string, config map[string]string, platformMC platforms.MatchComparer) (Driver, error) {
 	switch typ {
 	case "nydus":
-		return nydus.New(config)
+		return nydus.New(config, platformMC)
 	case "estargz":
-		return estargz.New(config)
+		return estargz.New(config, platformMC)
 	default:
 		return nil, fmt.Errorf("unsupported driver %s", typ)
 	}

--- a/pkg/driver/estargz/estargz.go
+++ b/pkg/driver/estargz/estargz.go
@@ -28,11 +28,12 @@ import (
 )
 
 type Driver struct {
-	cfg map[string]string
+	cfg        map[string]string
+	platformMC platforms.MatchComparer
 }
 
-func New(cfg map[string]string) (*Driver, error) {
-	return &Driver{cfg}, nil
+func New(cfg map[string]string, platformMC platforms.MatchComparer) (*Driver, error) {
+	return &Driver{cfg, platformMC}, nil
 }
 
 func (d *Driver) Convert(ctx context.Context, p content.Provider, ref string) (*ocispec.Descriptor, error) {
@@ -40,12 +41,11 @@ func (d *Driver) Convert(ctx context.Context, p content.Provider, ref string) (*
 	if err != nil {
 		return nil, errors.Wrap(err, "parse estargz conversion options")
 	}
-	platformMC := platforms.All // TODO: enable to configure the target platforms
 	image, err := p.Image(ctx, ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "get source image")
 	}
-	return converter.DefaultIndexConvertFunc(estargzconvert.LayerConvertFunc(opts...), docker2oci, platformMC)(
+	return converter.DefaultIndexConvertFunc(estargzconvert.LayerConvertFunc(opts...), docker2oci, d.platformMC)(
 		ctx, p.ContentStore(), *image)
 }
 

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -56,6 +56,7 @@ type Driver struct {
 	chunkSize        string
 	prefetchPatterns string
 	backend          backend.Backend
+	platformMC       platforms.MatchComparer
 }
 
 func parseBool(v string) (bool, error) {
@@ -70,7 +71,7 @@ func parseBool(v string) (bool, error) {
 	return parsed, nil
 }
 
-func New(cfg map[string]string) (*Driver, error) {
+func New(cfg map[string]string, platformMC platforms.MatchComparer) (*Driver, error) {
 	workDir := cfg["work_dir"]
 	if workDir == "" {
 		workDir = os.TempDir()
@@ -153,6 +154,7 @@ func New(cfg map[string]string) (*Driver, error) {
 		chunkSize:        fsChunkSize,
 		prefetchPatterns: prefetchPatterns,
 		backend:          _backend,
+		platformMC:       platformMC,
 	}, nil
 }
 
@@ -218,7 +220,7 @@ func (d *Driver) convert(ctx context.Context, provider accelcontent.Provider, so
 	indexConvertFunc := converter.IndexConvertFuncWithHook(
 		nydusify.LayerConvertFunc(packOpt),
 		d.docker2oci,
-		platforms.DefaultStrict(),
+		d.platformMC,
 		convertHooks,
 	)
 	return indexConvertFunc(ctx, cs, source)

--- a/pkg/platformutil/platformutil.go
+++ b/pkg/platformutil/platformutil.go
@@ -1,0 +1,85 @@
+package platformutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containerd/containerd/platforms"
+	nydusUtils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Ported from nerdctl project, copyright The containerd Authors.
+// https://github.com/containerd/nerdctl/blob/0f1c52a2d5c76b49789699d0a0018a99e4c1cff8/pkg/strutil/strutil.go#L72
+func dedupeStrSlice(in []string) []string {
+	m := make(map[string]struct{})
+	var res []string
+	for _, s := range in {
+		if _, ok := m[s]; !ok {
+			res = append(res, s)
+			m[s] = struct{}{}
+		}
+	}
+	return res
+}
+
+// Parse platform strings into MatchComparer, ss is multiple platforms split by ",",
+// For example: linux/amd64,linux/arm64
+func ParsePlatforms(all bool, ss string) (platforms.MatchComparer, error) {
+	platforms := []string{}
+	for _, plat := range strings.Split(ss, ",") {
+		plat := strings.TrimSpace(plat)
+		if plat != "" {
+			platforms = append(platforms, plat)
+		}
+	}
+	platformMC, err := NewMatchComparer(all, platforms)
+	if err != nil {
+		return nil, err
+	}
+	return nydusUtils.ExcludeNydusPlatformComparer{MatchComparer: platformMC}, nil
+}
+
+// Ported from nerdctl project, copyright The containerd Authors.
+// https://github.com/containerd/nerdctl/blob/0f1c52a2d5c76b49789699d0a0018a99e4c1cff8/pkg/platformutil/platformutil.go#L40
+//
+// NewMatchComparer returns MatchComparer.
+// If all is true, NewMatchComparer always returns All, regardless to the value of ss.
+// If all is false and ss is empty, NewMatchComparer returns DefaultStrict (not Default).
+// Otherwise NewMatchComparer returns Ordered MatchComparer.
+func NewMatchComparer(all bool, ss []string) (platforms.MatchComparer, error) {
+	if all {
+		return platforms.All, nil
+	}
+	if len(ss) == 0 {
+		// return DefaultStrict, not Default
+		return platforms.DefaultStrict(), nil
+	}
+	op, err := NewOCISpecPlatformSlice(false, ss)
+	return platforms.Ordered(op...), err
+}
+
+// Ported from nerdctl project, copyright The containerd Authors.
+// https://github.com/containerd/nerdctl/blob/0f1c52a2d5c76b49789699d0a0018a99e4c1cff8/pkg/platformutil/platformutil.go#L56
+//
+// NewOCISpecPlatformSlice returns a slice of ocispec.Platform
+// If all is true, NewOCISpecPlatformSlice always returns an empty slice, regardless to the value of ss.
+// If all is false and ss is empty, NewOCISpecPlatformSlice returns DefaultSpec.
+// Otherwise NewOCISpecPlatformSlice returns the slice that correspond to ss.
+func NewOCISpecPlatformSlice(all bool, ss []string) ([]ocispec.Platform, error) {
+	if all {
+		return nil, nil
+	}
+	if dss := dedupeStrSlice(ss); len(dss) > 0 {
+		var op []ocispec.Platform
+		for _, s := range dss {
+			p, err := platforms.Parse(s)
+			if err != nil {
+				return nil, fmt.Errorf("invalid platform: %q", s)
+			}
+			op = append(op, p)
+		}
+		return op, nil
+	}
+	return []ocispec.Platform{platforms.DefaultSpec()}, nil
+}


### PR DESCRIPTION
**nydus: support more options**

- Add `backend_force_push` option;
- Add `docker2oci` option;
- Add `fs_align_chunk` option;
- Add `fs_chunk_size` option;
- Add `prefetch_patterns` option;

See `misc/config/config.nydus.yaml` for option explanation.

**refine converter codes**

- Rename `LocalConverter` to `Converter`;
- Should enable `UpdateLayerDiffID` func ability in exported `Converter`;
- Move `LocalProvider` codes into separate file;

**support converting images for specific platforms**

Allow users specify `platforms` option in configuration to convert
images for specific platforms, leave empty for all platforms.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>