### PR TITLE
fix: filter platforms when set metric ImageSize

### DIFF
--- a/pkg/converter/converter.go
+++ b/pkg/converter/converter.go
@@ -124,7 +124,7 @@ func (cvt *Converter) Convert(ctx context.Context, source, target string) (*Metr
 		return nil, errors.Wrap(err, "convert image")
 	}
 	metric.ConversionElapsed = time.Since(start)
-	if err := metric.SetTargetImageSize(ctx, cvt.provider.ContentStore(), desc); err != nil {
+	if err := metric.SetTargetImageSize(ctx, cvt, desc); err != nil {
 		return nil, errors.Wrap(err, "get target image size")
 	}
 	logger.Infof("converted image %s, elapse %s", target, metric.ConversionElapsed)

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -118,7 +118,7 @@ func New(cfg map[string]string, platformMC platforms.MatchComparer) (*Driver, er
 		// For compatibility of older configuration.
 		fsVersion = cfg["rafs_version"]
 		if fsVersion == "" {
-			fsVersion = "5"
+			fsVersion = "6"
 		}
 	}
 	compressor := cfg["compressor"]


### PR DESCRIPTION
When we pull the image, we filter the platform, but the index descriptor will include all platforms. In that case, when we need to calculate the SourceImageSize, we will get error platform manifests. We can't find blobs locally.