### PR TITLE
feat: use lease to manage local cache for gc

### DIFF
--- a/pkg/content/bucket.go
+++ b/pkg/content/bucket.go
@@ -18,21 +18,24 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/opencontainers/go-digest"
 	bolt "go.etcd.io/bbolt"
 )
 
 var (
 	bucketKeyObjectContent = []byte("content")
 	bucketKeyObjectBlob    = []byte("blob")
+	bucketKeyObjectLeases  = []byte("leases")
 
 	bucketKeyVersion   = []byte("v1")
 	bucketKeyNamespace = []byte(accelerationServiceNamespace)
 	bucketKeySize      = []byte("size")
-	bucketKeyUpdatedAt = []byte("updatedat")
 )
 
-const accelerationServiceNamespace = "acceleration-service"
+const (
+	accelerationServiceNamespace = "acceleration-service"
+	usedAtLabel                  = "usedat"
+	usedCountLabel               = "usedcount"
+)
 
 func getBucket(tx *bolt.Tx, keys ...[]byte) *bolt.Bucket {
 	bucket := tx.Bucket(keys[0])
@@ -52,9 +55,9 @@ func getBlobsBucket(tx *bolt.Tx) *bolt.Bucket {
 	return getBucket(tx, bucketKeyVersion, bucketKeyNamespace, bucketKeyObjectContent, bucketKeyObjectBlob)
 }
 
-// getBlobBucket return the blob bucket by digest
-func getBlobBucket(tx *bolt.Tx, digst digest.Digest) *bolt.Bucket {
-	return getBucket(tx, bucketKeyVersion, bucketKeyNamespace, bucketKeyObjectContent, bucketKeyObjectBlob, []byte(digst.String()))
+// get the lease bucket by lease id
+func getLeaseBucket(tx *bolt.Tx, lease string) *bolt.Bucket {
+	return getBucket(tx, bucketKeyVersion, bucketKeyNamespace, bucketKeyObjectLeases, []byte(lease))
 }
 
 // bolbSize return the content blob size in a bucket


### PR DESCRIPTION
Now acceld's ```GarbageCollect``` will clear all caches when content size is over the threshold. We should use the lease to choose which content blob should be reserved. The ```updatedAt``` can help us to choose blobs.

Changes:
- Rename the ```updatedAt``` to ```usedat``` and move to lease bucket (labels).
- Add the ```usedCountLabel``` in lease bucket.
- Rewrite GC by lease. When the local cache size is over eighty percent of the threshold, gc will delete local blobs until the size is less than eighty percent of the threshold which is order by ```usedat```(LRU).

TODO:
We should update the order of GC from ```LRU``` to ```LRFU``` by ```usedCountLabel```.

Reference: https://github.com/goharbor/acceleration-service/issues/141.