### PR TITLE
nydus: support with_referrer option

### DIFF
--- a/misc/config/config.nydus.ref.yaml
+++ b/misc/config/config.nydus.ref.yaml
@@ -51,6 +51,13 @@ converter:
 
       # convert to OCI-referenced nydus zran image.
       oci_ref: true
+
+      # with this option, we can track all nydus images associated with
+      # an OCI image. For example, in Harbor we can cascade to show nydus
+      # images linked to an OCI image, deleting the OCI image can also delete
+      # the corresponding nydus images. At runtime, nydus snapshotter can also
+      # automatically upgrade an OCI image run to nydus image.
+      with_referrer: true
   rules:
     # add suffix to tag of source image reference as target image reference
     - tag_suffix: -nydus-oci-ref

--- a/misc/config/config.nydus.yaml
+++ b/misc/config/config.nydus.yaml
@@ -52,6 +52,13 @@ converter:
       # convert to OCI-referenced nydus zran image.
       # oci_ref: false
 
+      # with this option, we can track all nydus images associated with
+      # an OCI image. For example, in Harbor we can cascade to show nydus
+      # images linked to an OCI image, deleting the OCI image can also delete
+      # the corresponding nydus images. At runtime, nydus snapshotter can also
+      # automatically upgrade an OCI image run to nydus image.
+      with_referrer: true
+
       # specify nydus format version, possible values: `5`, `6` (EROFS-compatible), default is `6`
       # fs_version: 6
 

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -78,6 +78,7 @@ type Driver struct {
 	backend           backend.Backend
 	platformMC        platforms.MatchComparer
 	encryptRecipients []string
+	withReferrer      bool
 }
 
 func detectBuilderVersion(ctx context.Context, builder string) string {
@@ -175,6 +176,11 @@ func New(cfg map[string]string, platformMC platforms.MatchComparer) (*Driver, er
 		return nil, errors.Wrap(err, "invalid oci_ref option")
 	}
 
+	withReferrer, err := parseBool(cfg["with_referrer"])
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid with_referrer option")
+	}
+
 	encryptRecipients := []string{}
 	if cfg["encrypt_recipients"] != "" {
 		encryptRecipients = strings.Split(cfg["encrypt_recipients"], ",")
@@ -201,6 +207,7 @@ func New(cfg map[string]string, platformMC platforms.MatchComparer) (*Driver, er
 		backend:           _backend,
 		platformMC:        platformMC,
 		encryptRecipients: encryptRecipients,
+		withReferrer:      withReferrer,
 	}, nil
 }
 
@@ -263,6 +270,7 @@ func (d *Driver) convert(ctx context.Context, provider accelcontent.Provider, so
 		OCI:               d.docker2oci,
 		OCIRef:            packOpt.OCIRef,
 		EncryptRecipients: d.encryptRecipients,
+		WithReferrer:      d.withReferrer,
 	}
 	convertHookFunc := func(
 		ctx context.Context, cs content.Store, orgDesc ocispec.Descriptor, newDesc *ocispec.Descriptor,


### PR DESCRIPTION
With `with_referrer: true`, we can track all nydus images associated with
an OCI image. For example, in Harbor we can cascade to show nydus
images linked to an OCI image, deleting the OCI image can also delete
the corresponding nydus images. At runtime, nydus snapshotter can also
automatically upgrade an OCI image run to nydus image.