### PR TITLE
fix: use same cache repo for different tagged repo

### DIFF
--- a/misc/config/config.nydus.ref.yaml
+++ b/misc/config/config.nydus.ref.yaml
@@ -63,5 +63,5 @@ converter:
   rules:
     # add suffix to tag of source image reference as target image reference
     - tag_suffix: -nydus-oci-ref
-    # add suffix to tag of source image reference as remote cache reference, leave empty to disable remote cache.
-    - cache_tag_suffix: -nydus-cache
+    # set tag of source image reference as remote cache reference, leave empty to disable remote cache.
+    - cache_tag: nydus-cache

--- a/misc/config/config.nydus.yaml
+++ b/misc/config/config.nydus.yaml
@@ -102,5 +102,5 @@ converter:
   rules:
     # add suffix to tag of source image reference as target image reference
     - tag_suffix: -nydus
-    # add suffix to tag of source image reference as remote cache reference, leave empty to disable remote cache.
-    - cache_tag_suffix: -nydus-cache
+    # set tag of source image reference as remote cache reference, leave empty to disable remote cache.
+    - cache_tag: nydus-cache

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -103,9 +103,9 @@ func (adp *LocalAdapter) Convert(ctx context.Context, source string) error {
 		}
 		return errors.Wrap(err, "create target reference by rule")
 	}
-	cacheRef, err := adp.rule.Map(source, CacheTagSuffix)
+	cacheRef, err := adp.rule.Map(source, CacheTag)
 	if err != nil {
-		if errors.Is(err, errdefs.ErrIsRemoteCache) {
+		if errors.Is(err, errdefs.ErrSameTag) {
 			logrus.Infof("image was remote cache: %s", source)
 			return nil
 		}

--- a/pkg/adapter/rule.go
+++ b/pkg/adapter/rule.go
@@ -15,18 +15,18 @@
 package adapter
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/goharbor/acceleration-service/pkg/config"
 	"github.com/goharbor/acceleration-service/pkg/errdefs"
+	"github.com/pkg/errors"
 )
 
 const (
-	TagSuffix      = "tag_suffix"
-	CacheTagSuffix = "cache_tag_suffix"
+	TagSuffix = "tag_suffix"
+	CacheTag  = "cache_tag"
 )
 
 // Add suffix to source image reference as the target
@@ -36,13 +36,31 @@ const (
 func addSuffix(ref, suffix string) (string, error) {
 	named, err := docker.ParseDockerRef(ref)
 	if err != nil {
-		return "", fmt.Errorf("invalid source image reference: %s", err)
+		return "", errors.Wrap(err, "invalid source image reference")
 	}
 	if _, ok := named.(docker.Digested); ok {
 		return "", fmt.Errorf("unsupported digested image reference: %s", named.String())
 	}
 	named = docker.TagNameOnly(named)
 	target := named.String() + suffix
+	return target, nil
+}
+
+// setReferenceTag sets reference tag to source image reference as the target image reference, for example:
+// Source:192.168.1.1/nginx:latest
+// Target:192.168.1.1/nginx:tag
+func setReferenceTag(ref, tag string) (string, error) {
+	named, err := docker.ParseDockerRef(ref)
+	if err != nil {
+		return "", errors.Wrap(err, "invalid source image reference")
+	}
+	if _, ok := named.(docker.Digested); ok {
+		return "", fmt.Errorf("unsupported digested image reference: %s", named.String())
+	}
+	if tagged, ok := named.(docker.NamedTagged); ok && tagged.Tag() == tag {
+		return "", errdefs.ErrSameTag
+	}
+	target := named.Name() + ":" + tag
 	return target, nil
 }
 
@@ -65,17 +83,13 @@ func (rule *Rule) Map(ref, opt string) (string, error) {
 				return addSuffix(ref, item.TagSuffix)
 			}
 		}
-	case CacheTagSuffix:
+	case CacheTag:
 		for _, item := range rule.items {
-			if item.CacheTagSuffix != "" {
-				if strings.HasSuffix(ref, item.CacheTagSuffix) {
-					// FIXME: Ditto.A better way is to use the annotation on image manifest.
-					return "", errdefs.ErrIsRemoteCache
-				}
-				return addSuffix(ref, item.CacheTagSuffix)
+			if item.CacheTag != "" {
+				return setReferenceTag(ref, item.CacheTag)
 			}
 		}
-		// CacheTagSuffix empty means do not provide remote cache, just return empty string.
+		// CacheTag empty means do not provide remote cache, just return empty string.
 		return "", nil
 	default:
 		return "", fmt.Errorf("unsupported map option: %s", opt)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,8 +67,8 @@ type SourceConfig struct {
 }
 
 type ConversionRule struct {
-	TagSuffix      string `yaml:"tag_suffix"`
-	CacheTagSuffix string `yaml:"cache_tag_suffix"`
+	TagSuffix string `yaml:"tag_suffix"`
+	CacheTag  string `yaml:"cache_tag"`
 }
 
 type ConverterConfig struct {
@@ -142,7 +142,7 @@ func (cfg *Config) Host(ref string) (remote.CredentialFunc, bool, error) {
 
 func (cfg *Config) EnableRemoteCache() bool {
 	for _, rule := range cfg.Converter.Rules {
-		if rule.CacheTagSuffix != "" {
+		if rule.CacheTag != "" {
 			return true
 		}
 	}

--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -17,7 +17,7 @@ var (
 	ErrConvertFailed    = errors.New("ERR_CONVERT_FAILED")
 	ErrAlreadyConverted = errors.New("ERR_ALREADY_CONVERTED")
 	ErrUnhealthy        = errors.New("ERR_UNHEALTHY")
-	ErrIsRemoteCache    = errors.New("ERR_IS_REMOTE_CACHE")
+	ErrSameTag          = errors.New("ERR_SAME_TAG")
 	ErrNotSupport       = errors.New("ERR_NOT_SUPPORT")
 )
 


### PR DESCRIPTION
Now  same repoes with different tag converts with same cache repo, but the cache tag is different. This will result in very few or even no use of the cache layer in the converted cache, so we have make the same repo using the same tagged cache repo.

change
- make cache repo with same tag