### PR TITLE
feat: handle different plantform in cache remote

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -125,9 +125,6 @@ func (adp *LocalAdapter) Convert(ctx context.Context, source string) (*converter
 		}
 		return nil, errors.Wrap(err, "create cache reference by rule")
 	}
-	if err = adp.content.NewRemoteCache(cacheRef); err != nil {
-		return nil, err
-	}
 	adp.content.GcMutex.RLock()
 	defer adp.content.GcMutex.RUnlock()
 	metric, err := adp.cvt.Convert(ctx, source, target, cacheRef)

--- a/pkg/content/cache.go
+++ b/pkg/content/cache.go
@@ -17,15 +17,32 @@ package content
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"sort"
 	"strconv"
+	"sync"
+
+	"bytes"
+	"encoding/json"
 
 	"github.com/containerd/containerd/leases"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/goharbor/acceleration-service/pkg/remote"
 	lru "github.com/hashicorp/golang-lru/v2"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/content"
+	containerdErrDefs "github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	nydusutils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+	"github.com/goharbor/acceleration-service/pkg/errdefs"
+	"github.com/goharbor/acceleration-service/pkg/utils"
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 // This is not thread-safe, which means it will depend on the parent implementation to do the locking mechanism.
@@ -125,10 +142,17 @@ func (leaseCache *leaseCache) Len() int {
 	return leaseCache.size
 }
 
+type key int
+
+const (
+	Cache key = iota
+)
+
 type RemoteCache struct {
-	// remoteCache is an LRU cache for caching target layer descriptors, the cache key is the source layer digest,
+	mutex sync.Mutex
+	// remoteCache is a map for caching target layer descriptors, the cache key is the source layer digest,
 	// and the cache value is the target layer descriptor after conversion.
-	remoteCache *lru.Cache[string, ocispec.Descriptor]
+	remoteCache map[string]ocispec.Descriptor
 	// cacheRef is the remote cache reference.
 	cacheRef string
 	// host is a func to provide registry credential by host name.
@@ -137,48 +161,340 @@ type RemoteCache struct {
 	cacheSize int
 }
 
-func NewRemoteCache(cacheSize int, host remote.HostFunc) (*RemoteCache, error) {
-	remoteCache, err := lru.New[string, ocispec.Descriptor](cacheSize)
-	if err != nil {
-		return nil, err
-	}
+func NewRemoteCache(cacheSize int, cacheRef string, host remote.HostFunc) (*RemoteCache, error) {
 	return &RemoteCache{
-		remoteCache: remoteCache,
+		remoteCache: make(map[string]ocispec.Descriptor),
 		host:        host,
 		cacheSize:   cacheSize,
+		cacheRef:    cacheRef,
 	}, nil
 }
 
 func (rc *RemoteCache) Values() []ocispec.Descriptor {
-	return rc.remoteCache.Values()
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	var values []ocispec.Descriptor
+	for _, desc := range rc.remoteCache {
+		values = append(values, desc)
+	}
+	return values
 }
 
 func (rc *RemoteCache) Get(key string) (ocispec.Descriptor, bool) {
-	return rc.remoteCache.Get(key)
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	value, ok := rc.remoteCache[key]
+	return value, ok
 }
 
 func (rc *RemoteCache) Add(key string, value ocispec.Descriptor) {
-	rc.remoteCache.Add(key, value)
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	rc.remoteCache[key] = value
 }
 
-func (rc *RemoteCache) Remove(key string) {
-	rc.remoteCache.Remove(key)
-}
+// Fetch fetch cache manifest from remote
+func (rc *RemoteCache) Fetch(ctx context.Context, pvd Provider, platformMC platforms.MatchComparer) (*ocispec.Descriptor, error) {
+	resolver, err := pvd.Resolver(rc.cacheRef)
+	if err != nil {
+		return nil, err
+	}
 
-// Size returns the number of items in the cache.
-func (rc *RemoteCache) Size() int {
-	return rc.remoteCache.Len()
+	remoteContext := &containerd.RemoteContext{
+		Resolver:        resolver,
+		PlatformMatcher: platformMC,
+	}
+	name, desc, err := remoteContext.Resolver.Resolve(ctx, rc.cacheRef)
+	if err != nil {
+		if errors.Is(err, containerdErrDefs.ErrNotFound) {
+			// Remote cache may do not exist, just return nil
+			return nil, nil
+		}
+		return nil, err
+	}
+	fetcher, err := remoteContext.Resolver.Fetcher(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	ir, err := fetcher.Fetch(ctx, desc)
+	if err != nil {
+		if errdefs.NeedsRetryWithHTTP(err) {
+			pvd.UsePlainHTTP()
+			ir, err = fetcher.Fetch(ctx, desc)
+			if err != nil {
+				return nil, errors.Wrap(err, "try to pull remote cache")
+			}
+		} else {
+			return nil, errors.Wrap(err, "pull remote cache")
+		}
+	}
+	defer ir.Close()
+	mBytes, err := io.ReadAll(ir)
+	if err != nil {
+		return nil, errors.Wrap(err, "read remote cache bytes to manifest index")
+	}
 
-}
-
-func (rc *RemoteCache) NewLRUCache(cacheSize int, cacheRef string) error {
-	if rc != nil {
-		remoteCache, err := lru.New[string, ocispec.Descriptor](cacheSize)
+	cs := pvd.ContentStore()
+	switch desc.MediaType {
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		manifestIndex := ocispec.Index{}
+		if err = json.Unmarshal(mBytes, &manifestIndex); err != nil {
+			return nil, err
+		}
+		manifestIndexDesc, _, err := nydusutils.MarshalToDesc(manifestIndex, ocispec.MediaTypeImageIndex)
 		if err != nil {
+			return nil, errors.Wrap(err, "marshal remote cache manifest index")
+		}
+		if err = content.WriteBlob(ctx, cs, rc.cacheRef, bytes.NewReader(mBytes), *manifestIndexDesc); err != nil {
+			return nil, errors.Wrap(err, "write remote cache manifest index")
+		}
+		for _, manifest := range manifestIndex.Manifests {
+			mDesc := ocispec.Descriptor{
+				MediaType: manifest.MediaType,
+				Digest:    manifest.Digest,
+				Size:      manifest.Size,
+			}
+			mir, err := fetcher.Fetch(ctx, mDesc)
+			if err != nil {
+				return nil, errors.Wrap(err, "fetch remote cache")
+			}
+			manifestBytes, err := io.ReadAll(mir)
+			if err != nil {
+				return nil, errors.Wrap(err, "read remote cache manifest")
+			}
+			if err = content.WriteBlob(ctx, cs, rc.cacheRef, bytes.NewReader(manifestBytes), mDesc); err != nil {
+				return nil, errors.Wrap(err, "write remote cache manifest")
+			}
+		}
+
+		// Get manifests which matches specified platforms and put them into lru cache
+		matchDescs, err := utils.GetManifests(ctx, cs, *manifestIndexDesc, platformMC)
+		if err != nil {
+			return nil, errors.Wrap(err, "get remote cache manifest list")
+		}
+		var targetManifests []ocispec.Manifest
+		for _, desc := range matchDescs {
+			targetManifest := ocispec.Manifest{}
+			_, err = utils.ReadJSON(ctx, cs, &targetManifest, desc)
+			if err != nil {
+				return nil, errors.Wrap(err, "read remote cache manifest")
+			}
+			targetManifests = append(targetManifests, targetManifest)
+
+		}
+		for _, manifest := range targetManifests {
+			for _, layer := range manifest.Layers {
+				sourceDesc, ok := layer.Annotations[nydusutils.LayerAnnotationNydusSourceDigest]
+				if ok {
+					rc.Add(sourceDesc, layer)
+				}
+			}
+		}
+		return manifestIndexDesc, nil
+	default:
+		return nil, fmt.Errorf("unsupported cache image mediatype %s", desc.MediaType)
+	}
+}
+
+// push cache manifest to remote
+func (rc *RemoteCache) push(ctx context.Context, pvd Provider, cacheIndex *ocispec.Index) error {
+	for _, manifest := range cacheIndex.Manifests {
+		if err := pvd.Push(ctx, manifest, rc.cacheRef); err != nil {
 			return err
 		}
-		rc.remoteCache = remoteCache
-		rc.cacheRef = cacheRef
 	}
-	return nil
+	manifestIndexDesc, manifestIndexBytes, err := nydusutils.MarshalToDesc(*cacheIndex, ocispec.MediaTypeImageIndex)
+	if err != nil {
+		return errors.Wrap(err, "marshal remote cache manifest index")
+	}
+	if err = content.WriteBlob(ctx, pvd.ContentStore(), rc.cacheRef, bytes.NewReader(manifestIndexBytes), *manifestIndexDesc); err != nil {
+		return errors.Wrap(err, "write remote cache manifest index")
+	}
+	return pvd.Push(ctx, *manifestIndexDesc, rc.cacheRef)
+}
+
+// update cache layer from upper to lower, and generate corresponding cache manifest with converted image descriptor
+func (rc *RemoteCache) update(ctx context.Context, provider Provider, orgDesc, newDesc, cacheDesc *ocispec.Descriptor,
+	platformMC platforms.MatchComparer) (*ocispec.Index, error) {
+	cs := provider.ContentStore()
+	cacheLayers := map[*platforms.Platform][]ocispec.Descriptor{}
+
+	switch orgDesc.MediaType {
+	case ocispec.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
+		targetLayers, err := getConvertedLayers(ctx, cs, *orgDesc, *newDesc)
+		if err != nil {
+			return nil, err
+		}
+		// platform of original or new image maybe lost, get from config platform
+		platform, err := images.Platforms(ctx, cs, *orgDesc)
+		if err != nil {
+			return nil, err
+		}
+		cacheLayers[&platform[0]] = targetLayers
+
+	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
+		orgManifests, err := utils.GetManifests(ctx, cs, *orgDesc, platformMC)
+		if err != nil {
+			return nil, errors.Wrap(err, "get original manifest list")
+		}
+		newManifests, err := utils.GetManifests(ctx, cs, *newDesc, platformMC)
+		if err != nil {
+			return nil, errors.Wrap(err, "get new manifest list")
+		}
+		for _, newManifestDesc := range newManifests {
+			targetLayers := []ocispec.Descriptor{}
+			newManiPlatforms, err := images.Platforms(ctx, cs, newManifestDesc)
+			if err != nil {
+				return nil, errors.Wrap(err, "get converted manifest platforms")
+			}
+			// find original manifest matches converted manifest's platform
+			matcher := platforms.NewMatcher(newManiPlatforms[0])
+			for _, orgManifestDesc := range orgManifests {
+				orgManiPlatforms, err := images.Platforms(ctx, cs, orgManifestDesc)
+				if err != nil {
+					return nil, errors.Wrap(err, "get original manifest platforms")
+				}
+
+				if matcher.Match(orgManiPlatforms[0]) {
+					targetLayers, err = getConvertedLayers(ctx, cs, orgManifestDesc, newManifestDesc)
+					if err != nil {
+						return nil, err
+					}
+					break
+				}
+			}
+			cacheLayers[newManifestDesc.Platform] = targetLayers
+		}
+	}
+
+	imageConfig := ocispec.ImageConfig{}
+	imageConfigDesc, imageConfigBytes, err := nydusutils.MarshalToDesc(imageConfig, ocispec.MediaTypeImageConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal remote cache image config")
+	}
+	if err = content.WriteBlob(ctx, cs, rc.cacheRef, bytes.NewReader(imageConfigBytes), *imageConfigDesc); err != nil {
+		return nil, errors.Wrap(err, "write remote cahce image config")
+	}
+
+	cacheIndex := ocispec.Index{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: []ocispec.Descriptor{},
+	}
+	// cacheDesc maybe nil if remote cache doesn't exists before
+	if cacheDesc != nil {
+		_, err = utils.ReadJSON(ctx, cs, &cacheIndex, *cacheDesc)
+		if err != nil {
+			return nil, errors.Wrap(err, "read cache manifest index")
+		}
+		for idx, maniDesc := range cacheIndex.Manifests {
+			matcher := platforms.NewMatcher(*maniDesc.Platform)
+			for platform, layers := range cacheLayers {
+				if matcher.Match(*platform) {
+					// append new cache layers to existed cache manifest
+					var manifest ocispec.Manifest
+					_, err = utils.ReadJSON(ctx, cs, &manifest, maniDesc)
+					if err != nil {
+						return nil, errors.Wrap(err, "read cache manifest")
+					}
+					manifest.Layers = appendLayers(manifest.Layers, layers, rc.cacheSize)
+					newManiDesc, err := utils.WriteJSON(ctx, cs, manifest, maniDesc, "", nil)
+					if err != nil {
+						return nil, errors.Wrap(err, "write cache manifest")
+					}
+					cacheIndex.Manifests[idx] = *newManiDesc
+					delete(cacheLayers, platform)
+				}
+			}
+		}
+	}
+
+	// append new cache layers to new cache manifest
+	for platform, layers := range cacheLayers {
+		manifest := ocispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			MediaType: ocispec.MediaTypeImageManifest,
+			Config:    *imageConfigDesc,
+			Layers:    layers,
+		}
+		manifestDesc, err := utils.WriteJSON(ctx, cs, manifest, ocispec.Descriptor{}, "", nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "write cache manifest")
+		}
+		cacheIndex.Manifests = append(cacheIndex.Manifests, ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Digest:    manifestDesc.Digest,
+			Size:      manifestDesc.Size,
+			Platform:  platform,
+		})
+	}
+	return &cacheIndex, nil
+}
+
+// UpdateAndPush updates cache layers from current conversion and push cache manifest to remote.
+func (rc *RemoteCache) UpdateAndPush(ctx context.Context, provider Provider, orgDesc, newDesc *ocispec.Descriptor, platformMC platforms.MatchComparer) error {
+	// Fetch the old remote cache before updating and pushing the new one to avoid conflict.
+	cacheDesc, err := rc.Fetch(ctx, provider, platformMC)
+	if err != nil {
+		return err
+	}
+	cacheIndex, err := rc.update(ctx, provider, orgDesc, newDesc, cacheDesc, platformMC)
+	if err != nil {
+		return err
+	}
+	return rc.push(ctx, provider, cacheIndex)
+}
+
+// getConvertedLayers get converted layers of nydus image and corresponding source image layers from the descriptor
+// from nydus image and source image
+func getConvertedLayers(ctx context.Context, cs content.Store, sourceManiDesc, targetManiDesc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	sourceManifest := ocispec.Manifest{}
+	_, err := utils.ReadJSON(ctx, cs, &sourceManifest, sourceManiDesc)
+	if err != nil {
+		return nil, errors.Wrap(err, "read original manifest json")
+	}
+
+	targetManifest := ocispec.Manifest{}
+	_, err = utils.ReadJSON(ctx, cs, &targetManifest, targetManiDesc)
+	if err != nil {
+		return nil, errors.Wrap(err, "read new manifest json")
+	}
+	// the final layer of Layers is boostrap layer of nydus image, it doesn't have corresponding source image layer
+	targetLayers := targetManifest.Layers[:len(targetManifest.Layers)-1]
+
+	// Update cache to cacheLayers from upper to lower and update layer laebl
+	cacheLayers := []ocispec.Descriptor{}
+	for i := len(targetLayers) - 1; i >= 0; i-- {
+		layer := targetLayers[i]
+		// Update <LayerAnnotationNydusSourceDigest> label for each layer
+		layer.Annotations[nydusutils.LayerAnnotationNydusSourceDigest] = sourceManifest.Layers[i].Digest.String()
+		cacheLayers = append(cacheLayers, layer)
+	}
+
+	return cacheLayers, nil
+}
+
+// appendLayersappend new cache layers to cache manifest layers, if new layer already exists, moving existed layers to front, avoiding to add duplicated layers.
+func appendLayers(orgDescs, newDescs []ocispec.Descriptor, size int) []ocispec.Descriptor {
+	moveFront := map[digest.Digest]bool{}
+	for _, desc := range orgDescs {
+		moveFront[desc.Digest] = true
+	}
+	mergedLayers := orgDescs
+	for _, desc := range newDescs {
+		if !moveFront[desc.Digest] {
+			mergedLayers = append(mergedLayers, desc)
+			if len(mergedLayers) >= size {
+				break
+			}
+		}
+	}
+	if len(mergedLayers) > size {
+		mergedLayers = mergedLayers[:size]
+	}
+	return mergedLayers
 }

--- a/pkg/content/cache_test.go
+++ b/pkg/content/cache_test.go
@@ -44,7 +44,7 @@ func TestLeaseCache(t *testing.T) {
 func TestLeaseCacheInit(t *testing.T) {
 	os.MkdirAll("./tmp", 0755)
 	defer os.RemoveAll("./tmp")
-	content, err := NewContent("./tmp", "./tmp", "100MB", false, 200, nil)
+	content, err := NewContent("./tmp", "./tmp", "100MB")
 	require.NoError(t, err)
 	testDigest := []string{
 		"sha256:9bb13890319dc01e5f8a4d3d0c4c72685654d682d568350fd38a02b1d70aee6b",

--- a/pkg/content/content_test.go
+++ b/pkg/content/content_test.go
@@ -15,112 +15,18 @@
 package content
 
 import (
-	"context"
 	"os"
 	"testing"
 
-	"github.com/containerd/containerd/content"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/stretchr/testify/require"
 )
 
 func TestContenSize(t *testing.T) {
 	os.MkdirAll("./tmp", 0755)
 	defer os.RemoveAll("./tmp")
-	content, err := NewContent("./tmp", "./tmp", "1000MB", false, 200, nil)
+	content, err := NewContent("./tmp", "./tmp", "1000MB")
 	require.NoError(t, err)
 	size, err := content.Size()
 	require.NoError(t, err)
 	require.Equal(t, size, int64(0))
-}
-
-func TestRemoteCacheFIFO(t *testing.T) {
-	os.MkdirAll("./tmp", 0755)
-	defer os.RemoveAll("./tmp")
-	cs, err := NewContent("./tmp", "./tmp", "1000MB", true, 5, nil)
-	require.NoError(t, err)
-
-	// Assume the following layers were already cached in remote cache
-	cs.remoteCache.Add("sha256:3ea3641165a4082d1feb7f933b11589a98f6b44906b3ab7224fd57afdb81bd22", ocispec.Descriptor{
-		Digest:    digest.Digest("sha256:937705f5a7ed2202ef5efab32f37940bcdc3f3bd8da5d472a605f92a1ee2abb8"),
-		MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
-		Size:      28104,
-		Annotations: map[string]string{
-			"containerd.io/snapshot/nydus-source-digest": "sha256:3ea3641165a4082d1feb7f933b11589a98f6b44906b3ab7224fd57afdb81bd22",
-		},
-	})
-	// This layer will be update by testTargetDesc, with different size.
-	cs.remoteCache.Add("sha256:d2a0c55811ee17d810756e8abe1c0e1680b83c1674b167116b5d22c92426271e", ocispec.Descriptor{
-		Digest:    digest.Digest("sha256:29de1420e90dc712e218943e2503bb8f8e7e0ea33094d21386fc6dfb6296cdaf"),
-		MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
-		Size:      30000000,
-		Annotations: map[string]string{
-			"containerd.io/snapshot/nydus-source-digest": "sha256:d2a0c55811ee17d810756e8abe1c0e1680b83c1674b167116b5d22c92426271e",
-		},
-	})
-	cs.remoteCache.Add("sha256:61c5a878f9b478eabfb7d805f8b28037bc75fc2723a8ed34a25ed926bb235630", ocispec.Descriptor{
-		Digest:    digest.Digest("sha256:5068ad3783f63b82ecf9434161923dec024275c2c09f79f517a8eaeba9765488"),
-		MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
-		Size:      4629756,
-		Annotations: map[string]string{
-			"containerd.io/snapshot/nydus-source-digest": "sha256:61c5a878f9b478eabfb7d805f8b28037bc75fc2723a8ed34a25ed926bb235630",
-		},
-	})
-
-	// The testTargetDesc is from a manifest, will be update to the remote cache.
-	// More closer to the front, more lower. More closer to the back, more upper.
-	testTargetDesc := []ocispec.Descriptor{
-		{
-			Digest:    digest.Digest("sha256:281acccc8425676d6cb1840e2656409f58da7e0e8d4c07f9092d35f9c9810e20"),
-			MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
-			Size:      39784900,
-			Annotations: map[string]string{
-				"containerd.io/snapshot/nydus-source-digest": "sha256:ccc37bca66e7c29e0d65a4279511fe9a93932a4bb80e79e95144f3812632b61a",
-			},
-		},
-		{
-			Digest:    digest.Digest("sha256:29de1420e90dc712e218943e2503bb8f8e7e0ea33094d21386fc6dfb6296cdaf"),
-			MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
-			Size:      38238606,
-			Annotations: map[string]string{
-				"containerd.io/snapshot/nydus-source-digest": "sha256:d2a0c55811ee17d810756e8abe1c0e1680b83c1674b167116b5d22c92426271e",
-			},
-		},
-		{
-			Digest:    digest.Digest("sha256:a3a8cb24ca266f5d7513f2c8be9a140c9f5abe223e0d80c68024b2ad5b6c928a"),
-			MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
-			Size:      26308,
-			Annotations: map[string]string{
-				"containerd.io/snapshot/nydus-source-digest": "sha256:163d9761f77314ae2beb0cfdb0f86245bef6071233fece6a3e4a3d1d4db23c5f",
-			},
-		},
-		{
-			Digest:    digest.Digest("sha256:a9453f674413979bd6cdaaeb4399cd8d9c5449cf7625860e6d93eb2f916b4e50"),
-			MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
-			Size:      26315,
-			Annotations: map[string]string{
-				"containerd.io/snapshot/nydus-source-digest": "sha256:c767afe512614d4adf05b9136a92c89b6151804d41ca92f005ce3af0032c36de",
-			},
-		},
-	}
-
-	// Apdate cache to lru from upper to lower
-	ctx := context.Background()
-	for i := len(testTargetDesc) - 1; i >= 0; i-- {
-		layer := testTargetDesc[i]
-		_, err := cs.Update(ctx, content.Info{
-			Digest: layer.Digest,
-			Size:   layer.Size,
-			Labels: layer.Annotations,
-		})
-		require.NoError(t, err)
-	}
-	require.Equal(t, cs.remoteCache.Size(), 5)
-	require.Equal(t, "sha256:5068ad3783f63b82ecf9434161923dec024275c2c09f79f517a8eaeba9765488", cs.remoteCache.Values()[0].Digest.String())
-	require.Equal(t, "sha256:a9453f674413979bd6cdaaeb4399cd8d9c5449cf7625860e6d93eb2f916b4e50", cs.remoteCache.Values()[1].Digest.String())
-	require.Equal(t, "sha256:a3a8cb24ca266f5d7513f2c8be9a140c9f5abe223e0d80c68024b2ad5b6c928a", cs.remoteCache.Values()[2].Digest.String())
-	require.Equal(t, "sha256:29de1420e90dc712e218943e2503bb8f8e7e0ea33094d21386fc6dfb6296cdaf", cs.remoteCache.Values()[3].Digest.String())
-	require.Equal(t, int64(38238606), cs.remoteCache.Values()[3].Size)
-	require.Equal(t, "sha256:281acccc8425676d6cb1840e2656409f58da7e0e8d4c07f9092d35f9c9810e20", cs.remoteCache.Values()[4].Digest.String())
 }

--- a/pkg/content/provider.go
+++ b/pkg/content/provider.go
@@ -42,8 +42,6 @@ type Provider interface {
 	Image(ctx context.Context, ref string) (*ocispec.Descriptor, error)
 	// ContentStore gets the content store object of containerd.
 	ContentStore() content.Store
-	// SetCacheRef sets the cache reference of the source image.
-	SetCacheRef(ref string)
-	// GetCacheRef gets the cache reference of the source image.
-	GetCacheRef() string
+	// RemoteCache gets the remote cache of the source reference.
+	NewRemoteCache(ref string) (*RemoteCache, bool)
 }

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -17,9 +17,9 @@ package nydus
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+
 	"fmt"
-	"io"
+
 	"os"
 	"os/exec"
 	"regexp"
@@ -27,9 +27,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
-	containerdErrDefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/platforms"
@@ -229,39 +227,12 @@ func (d *Driver) Convert(ctx context.Context, provider accelcontent.Provider, so
 	if err != nil {
 		return nil, errors.Wrap(err, "get source image")
 	}
-
-	cacheRef := provider.GetCacheRef()
-	useRemoteCache := cacheRef != ""
-	if useRemoteCache {
-		logrus.Infof("remote cache image reference: %s", cacheRef)
-		if err := d.FetchRemoteCache(ctx, provider, cacheRef); err != nil {
-			if errors.Is(err, errdefs.ErrNotSupport) {
-				logrus.Warn("Content store does not support remote cache")
-			} else {
-				return nil, errors.Wrap(err, "fetch remote cache")
-			}
-		}
-	}
-
 	desc, err := d.convert(ctx, provider, *image, sourceRef)
 	if err != nil {
 		return nil, err
 	}
 	if d.mergeManifest {
 		return d.makeManifestIndex(ctx, provider.ContentStore(), *image, *desc)
-	}
-
-	if useRemoteCache {
-		// Fetch the old remote cache before updating and pushing the new one to avoid conflict.
-		if err := d.FetchRemoteCache(ctx, provider, cacheRef); err != nil {
-			return nil, errors.Wrap(err, "fetch remote cache")
-		}
-		if err := d.UpdateRemoteCache(ctx, provider, *image, *desc); err != nil {
-			return nil, errors.Wrap(err, "update remote cache")
-		}
-		if err := d.PushRemoteCache(ctx, provider, cacheRef); err != nil {
-			return nil, errors.Wrap(err, "push remote cache")
-		}
 	}
 	return desc, err
 }
@@ -430,153 +401,4 @@ func (d *Driver) getChunkDict(ctx context.Context, provider accelcontent.Provide
 	}
 
 	return &chunkDict, nil
-}
-
-// FetchRemoteCache fetch cache manifest from remote
-func (d *Driver) FetchRemoteCache(ctx context.Context, pvd accelcontent.Provider, ref string) error {
-	resolver, err := pvd.Resolver(ref)
-	if err != nil {
-		return err
-	}
-
-	rc := &containerd.RemoteContext{
-		Resolver: resolver,
-	}
-	name, desc, err := rc.Resolver.Resolve(ctx, ref)
-	if err != nil {
-		if errors.Is(err, containerdErrDefs.ErrNotFound) {
-			// Remote cache may do not exist, just return nil
-			return nil
-		}
-		return err
-	}
-	fetcher, err := rc.Resolver.Fetcher(ctx, name)
-	if err != nil {
-		return err
-	}
-	ir, err := fetcher.Fetch(ctx, desc)
-	if err != nil {
-		if errdefs.NeedsRetryWithHTTP(err) {
-			pvd.UsePlainHTTP()
-			ir, err = fetcher.Fetch(ctx, desc)
-			if err != nil {
-				return errors.Wrap(err, "try to pull remote cache")
-			}
-		} else {
-			return errors.Wrap(err, "pull remote cache")
-		}
-	}
-
-	bytes, err := io.ReadAll(ir)
-	if err != nil {
-		return errors.Wrap(err, "read remote cache to bytes")
-	}
-
-	// TODO: handle manifest list for multiple platform.
-	manifest := ocispec.Manifest{}
-	if err = json.Unmarshal(bytes, &manifest); err != nil {
-		return err
-	}
-
-	cs := pvd.ContentStore()
-	for _, layer := range manifest.Layers {
-		if _, err := cs.Update(ctx, content.Info{
-			Digest: layer.Digest,
-			Size:   layer.Size,
-			Labels: layer.Annotations,
-		}); err != nil {
-			if errors.Is(err, containerdErrDefs.ErrNotFound) {
-				return errdefs.ErrNotSupport
-			}
-			return errors.Wrap(err, "update cache layer")
-		}
-	}
-	return nil
-}
-
-// PushRemoteCache update cache manifest and push to remote
-func (d *Driver) PushRemoteCache(ctx context.Context, pvd accelcontent.Provider, ref string) error {
-	imageConfig := ocispec.ImageConfig{}
-	imageConfigDesc, imageConfigBytes, err := nydusutils.MarshalToDesc(imageConfig, ocispec.MediaTypeImageConfig)
-	if err != nil {
-		return errors.Wrap(err, "remote cache image config marshal failed")
-	}
-	configReader := bytes.NewReader(imageConfigBytes)
-	if err = content.WriteBlob(ctx, pvd.ContentStore(), ref, configReader, *imageConfigDesc); err != nil {
-		return errors.Wrap(err, "remote cache image config write blob failed")
-	}
-
-	cs := pvd.ContentStore()
-	layers := []ocispec.Descriptor{}
-	if err = cs.Walk(ctx, func(info content.Info) error {
-		if _, ok := info.Labels[nydusutils.LayerAnnotationNydusSourceDigest]; ok {
-			layers = append(layers, ocispec.Descriptor{
-				MediaType:   nydusutils.MediaTypeNydusBlob,
-				Digest:      info.Digest,
-				Size:        info.Size,
-				Annotations: info.Labels,
-			})
-		}
-		return nil
-	}); err != nil {
-		return errors.Wrap(err, "get remote cache layers failed")
-	}
-
-	manifest := ocispec.Manifest{
-		Versioned: specs.Versioned{
-			SchemaVersion: 2,
-		},
-		MediaType: ocispec.MediaTypeImageManifest,
-		Config:    *imageConfigDesc,
-		Layers:    layers,
-	}
-	manifestDesc, manifestBytes, err := nydusutils.MarshalToDesc(manifest, ocispec.MediaTypeImageManifest)
-	if err != nil {
-		return errors.Wrap(err, "remote cache manifest marshal failed")
-	}
-	manifestReader := bytes.NewReader(manifestBytes)
-	if err = content.WriteBlob(ctx, pvd.ContentStore(), ref, manifestReader, *manifestDesc); err != nil {
-		return errors.Wrap(err, "remote cache write blob failed")
-	}
-
-	if err = pvd.Push(ctx, *manifestDesc, ref); err != nil {
-		return err
-	}
-	return nil
-}
-
-// UpdateRemoteCache update cache layer from upper to lower
-func (d *Driver) UpdateRemoteCache(ctx context.Context, provider accelcontent.Provider, orgDesc ocispec.Descriptor, newDesc ocispec.Descriptor) error {
-	cs := provider.ContentStore()
-
-	orgManifest := ocispec.Manifest{}
-	_, err := utils.ReadJSON(ctx, cs, &orgManifest, orgDesc)
-	if err != nil {
-		return errors.Wrap(err, "read original manifest json")
-	}
-
-	newManifest := ocispec.Manifest{}
-	_, err = utils.ReadJSON(ctx, cs, &newManifest, newDesc)
-	if err != nil {
-		return errors.Wrap(err, "read new manifest json")
-	}
-	newLayers := newManifest.Layers[:len(newManifest.Layers)-1]
-
-	// Update <LayerAnnotationNydusSourceDigest> label for each layer
-	for i, layer := range newLayers {
-		layer.Annotations[nydusutils.LayerAnnotationNydusSourceDigest] = orgManifest.Layers[i].Digest.String()
-	}
-
-	// Update cache to lru from upper to lower
-	for i := len(newLayers) - 1; i >= 0; i-- {
-		layer := newLayers[i]
-		if _, err := cs.Update(ctx, content.Info{
-			Digest: layer.Digest,
-			Size:   layer.Size,
-			Labels: layer.Annotations,
-		}); err != nil {
-			return errors.Wrap(err, "update cache layer")
-		}
-	}
-	return nil
 }

--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -19,7 +19,6 @@ var (
 	ErrAlreadyConverted = errors.New("ERR_ALREADY_CONVERTED")
 	ErrUnhealthy        = errors.New("ERR_UNHEALTHY")
 	ErrSameTag          = errors.New("ERR_SAME_TAG")
-	ErrNotSupport       = errors.New("ERR_NOT_SUPPORT")
 )
 
 // IsErrHTTPResponseToHTTPSClient returns whether err is


### PR DESCRIPTION
We can use `manifestIndex `to record different remote cache on different plantforms.
And conversion will use cache which matches current plantfotm.

changes:
- use manifest list to store different cache on different plantforms.