### PR TITLE
fix: retry without cache in inconsistent fs version

### DIFF
--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -8,6 +8,7 @@ package errdefs
 
 import (
 	"errors"
+	"os/exec"
 	"strings"
 )
 
@@ -39,4 +40,16 @@ func isErrConnectionRefused(err error) bool {
 
 func NeedsRetryWithHTTP(err error) bool {
 	return err != nil && (isErrHTTPResponseToHTTPSClient(err) || isErrConnectionRefused(err))
+}
+
+func isErrInconsistentNydusLayer(err error) bool {
+	var exiterr *exec.ExitError
+	if errors.As(err, &exiterr) && exiterr.ExitCode() == 2 {
+		return true
+	}
+	return false
+}
+
+func NeedsRetryWithoutCache(err error) bool {
+	return err != nil && (isErrInconsistentNydusLayer(err))
 }


### PR DESCRIPTION
If acceld converts with different fs version cache, leading to an inconsistent fs version problem when merging into boostrap layer. 

For example: cache manifest fs version is 5 and convert fs version is 6, this will lead to compatibility problems.

So a simple way is that  retrying without remote cache.

changes:
- Retry in adapter convert when encounter compatibility problems.
- move clear cache in provider