### PR TITLE
fix: checkout code in release upload_binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/out
     needs: [release_binary]
     steps:
+      - uses: actions/checkout@v4
       - name: Download Artifacts
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Fix an error created in https://github.com/goharbor/acceleration-service/pull/186.
![image](https://github.com/goharbor/acceleration-service/assets/59167816/1788b5ff-d71f-4e7d-bad8-f36d08565716)


We should checkout the repo in upload_binary.