### PR TITLE
feat: record metrics of conversion in task

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -64,11 +64,16 @@ GET /api/v1/conversions
         "created": "2022-04-06T06:45:11.83226503Z",
         "finished": "2022-04-06T06:45:11.948393604Z",
         "source": "192.168.1.1/library/nginx:latest",
+        "source_size": "70254592",
+        "target_size": "72351744",
         "status": "$status",
         "reason": "$reason"
     }
 ]
 ```
+`source_size`: uint, total size of the source image with specified platforms in bytes.
+
+`target_size`: uint, total size of the target image with specified platforms in bytes.
 
 `$status`: string, possible values is `PROCESSING`, `COMPLETED`, `FAILED`.
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/goharbor/acceleration-service/pkg/converter"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -75,14 +76,14 @@ func NewOpWrapper(scope string, labelNames []string) *OpWrapper {
 	}
 }
 
-func (metrics *OpWrapper) OpWrap(op func() error, lvs ...string) error {
+func (metrics *OpWrapper) OpWrap(op func() (*converter.Metric, error), lvs ...string) (*converter.Metric, error) {
 	start := time.Now()
 
-	err := op()
+	metric, err := op()
 	Duration(err, metrics.OpDuration, start, lvs...)
 	CountInc(err, metrics.OpTotal, metrics.OpErrorTotal, lvs...)
 
-	return err
+	return metric, err
 }
 
 func Duration(err error, metric *prometheus.HistogramVec, start time.Time, lvs ...string) {


### PR DESCRIPTION
We have collected the metrics of conversion progress. Let's show them in the task. Add the `SourceImageSize` and `TargetImageSize` in the task and record them when the task is finished.

resolve #191.