### PR TITLE
feat: support reading auth from docker config

### DIFF
--- a/misc/config/config.estargz.yaml
+++ b/misc/config/config.estargz.yaml
@@ -18,14 +18,15 @@ provider:
     hub.harbor.com:
       # base64 encoded `<robot-name>:<robot-secret>` for robot
       # account created in harbor
-      auth: YTpiCg==
+      # auth: YTpiCg==
       # skip verifying server certs for HTTPS source registry
       insecure: false
       webhook:
         # webhook request auth header configured in harbor
         auth_header: header
     localhost:
-      auth: YWRtaW46SGFyYm9yMTIzNDU=
+      # If auth is not provided, it will attempt to read from docker config
+      # auth: YWRtaW46SGFyYm9yMTIzNDU=
   # work directory of acceld
   work_dir: /tmp
   gcpolicy:

--- a/misc/config/config.nydus.ref.yaml
+++ b/misc/config/config.nydus.ref.yaml
@@ -18,14 +18,15 @@ provider:
     hub.harbor.com:
       # base64 encoded `<robot-name>:<robot-secret>` for robot
       # account created in harbor
-      auth: YTpiCg==
+      # auth: YTpiCg==
       # skip verifying server certs for HTTPS source registry
       insecure: false
       webhook:
         # webhook request auth header configured in harbor
         auth_header: header
     localhost:
-      auth: YWRtaW46SGFyYm9yMTIzNDU=
+      # If auth is not provided, it will attempt to read from docker config
+      # auth: YWRtaW46SGFyYm9yMTIzNDU=
   # work directory of acceld
   work_dir: /tmp
   gcpolicy:

--- a/misc/config/config.nydus.yaml
+++ b/misc/config/config.nydus.yaml
@@ -18,14 +18,15 @@ provider:
     hub.harbor.com:
       # base64 encoded `<robot-name>:<robot-secret>` for robot
       # account created in harbor
-      auth: YTpiCg==
+      # auth: YTpiCg==
       # skip verifying server certs for HTTPS source registry
       insecure: false
       webhook:
         # webhook request auth header configured in harbor
         auth_header: header
     localhost:
-      auth: YWRtaW46SGFyYm9yMTIzNDU=
+      # If auth is not provided, it will attempt to read from docker config
+      # auth: YWRtaW46SGFyYm9yMTIzNDU=
   # work directory of acceld
   work_dir: /tmp
   gcpolicy:

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -63,10 +63,7 @@ func NewLocalHandler(cfg *config.Config) (*LocalHandler, error) {
 
 func (handler *LocalHandler) Auth(ctx context.Context, host string, authHeader string) error {
 	if authHeader != "" {
-		source, ok := handler.cfg.Provider.Source[host]
-		if !ok {
-			return fmt.Errorf("not found config for host %s", host)
-		}
+		source := handler.cfg.Provider.Source[host]
 		if authHeader != source.Webhook.AuthHeader {
 			return fmt.Errorf("unmatched auth header for host %s", host)
 		}

--- a/script/integration/concurrent/config.yaml
+++ b/script/integration/concurrent/config.yaml
@@ -9,7 +9,8 @@ metric:
 provider:
   source:
     localhost:
-      auth: YWRtaW46SGFyYm9yMTIzNDU=
+      # If auth is not provided, it will attempt to read from docker config
+      # auth: YWRtaW46SGFyYm9yMTIzNDU=
   work_dir: /tmp
   gcpolicy:
       threshold: 10MB


### PR DESCRIPTION
User can don't put the auth in config file, just use `docker/nerdctl login`. 
Acceld will try to read registry auth from the docker config if cant't find auth in config file.

resolve #29 .