### PR TITLE
action: change wordpress to redis

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -12,7 +12,7 @@ env:
   GO_VERSION: 1.18
   HARBOR_VERSION: 2.8.4
   NYDUS_VERSION: 2.1.6
-  OCI_IMAGE_NAME: wordpress
+  OCI_IMAGE_NAME: redis
 
 jobs:
   accel_check:


### PR DESCRIPTION
We have test `wordpress` `nginx` `alpine` and `busybox` in Concurrent Test. 
Change test image in Integration Test from `wordpress` to `redis` to reduce test time and test more different images.