### PR TITLE
fix: delete repetitive unlock

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -133,7 +133,6 @@ func (adp *LocalAdapter) Convert(ctx context.Context, source string) (*converter
 				return nil, err
 			}
 		}
-		adp.content.GcMutex.RUnlock()
 		return nil, err
 	}
 	go adp.content.GC(ctx, adp.content.Threshold)


### PR DESCRIPTION
```
adp.content.GcMutex.RLock()
defer adp.content.GcMutex.RUnlock()
```
We use `RUnlock()` twice.

Signed-off-by: Yadong Ding <ding_yadong@foxmail.com>