### PR TITLE
fix: return cache map error when encountered

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -123,6 +123,7 @@ func (adp *LocalAdapter) Convert(ctx context.Context, source string) (*converter
 			logrus.Infof("image was remote cache: %s", source)
 			return nil, nil
 		}
+		return nil, errors.Wrap(err, "create cache reference by rule")
 	}
 	if err = adp.content.NewRemoteCache(cacheRef); err != nil {
 		return nil, err


### PR DESCRIPTION
Error should be return when encountered in cache reference mapping.