### PR TITLE
fix: blob lost and lack mutex protection

### DIFF
--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -271,16 +271,17 @@ func (content *Content) Update(ctx context.Context, info ctrcontent.Info, fieldp
 		}
 	}
 
-	info, err := content.store.Update(ctx, info, fieldpaths...)
-	if _, cached := cache.Update(ctx, info.Digest, info.Labels); cached != nil {
-		return ctrcontent.Info{
-			Digest: cached.Digest,
-			Size:   cached.Size,
-			Labels: cached.Annotations,
-		}, nil
+	updatedInfo, err := content.store.Update(ctx, info, fieldpaths...)
+	if errors.Is(err, errdefs.ErrNotFound) {
+		if _, cached := cache.Update(ctx, info.Digest, info.Labels); cached != nil {
+			return ctrcontent.Info{
+				Digest: cached.Digest,
+				Size:   cached.Size,
+				Labels: cached.Annotations,
+			}, nil
+		}
 	}
-
-	return info, err
+	return updatedInfo, err
 }
 
 func (content *Content) Walk(ctx context.Context, fn ctrcontent.WalkFunc, fs ...string) error {


### PR DESCRIPTION
If use `info` varible in `Update` of store and get error in store update, the return value `info` is empty, and cache `Update` will be useless.

change:
- rename `info` to `updateInfo`  in content wrap
- `Update` func of cache needs a mutex protection
- add cached info of a conversion like  log info 
   "pulled image xxx(cached 21/23)"
   "......"
   "converted image xxx(cached 21/23)"
   "......"