### PR TITLE
feat: build arm64 image

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@c64db31d359214d244884dd68f971a110b29ab83
+      uses: tim-actions/get-pr-commits@master
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,15 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: goharbor/harbor-acceld:${{ env.IMAGE_TAG }}
 
+    - name: Update repo description
+      uses: peter-evans/dockerhub-description@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        repository: goharbor/harbor-acceld
+        short-description:  ${{ github.event.repository.description }}
+        readme-filepath: ./README.md
+
   release_binary:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,61 +5,123 @@ on:
     tags:
       - 'v*'
 
+env:
+  REGISTRY_IMAGE: goharbor/harbor-acceld
+
 jobs:
-  release_image:
+  build_image:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-
-    - name: Export Image Tag
+    - name: Prepare
       run: |
-        echo "IMAGE_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
-
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY_IMAGE }}
+        tags: |
+          type=semver,pattern={{version}}
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-
-    - name: Build and Export to Docker
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        file: script/release/Dockerfile
-        load: true
-        tags: goharbor/harbor-acceld:${{ env.IMAGE_TAG }}
-
-    - name: Test Image
-      # Enable tty for docker
-      shell: 'script -q -e -c "bash {0}"'
-      run: |
-        docker run -v $PWD/misc/config/config.nydus.yaml:/etc/acceld-config.yaml -d --rm -p 2077:2077 goharbor/harbor-acceld:${{ env.IMAGE_TAG }} /etc/acceld-config.yaml
-        sleep 5
-        curl -f http://127.0.0.1:2077/api/v1/health
-
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-
-    - name: Build and Push
+    - name: Build and push by digest
+      id: build
       uses: docker/build-push-action@v5
       with:
         context: .
+        platforms: ${{ matrix.platform }}
         file: script/release/Dockerfile
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: goharbor/harbor-acceld:${{ env.IMAGE_TAG }}
-
-    - name: Update repo description
-      uses: peter-evans/dockerhub-description@v3
+        labels: ${{ steps.meta.outputs.labels }}
+        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+    - name: Export digest
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.build.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+    - name: Upload digest
+      uses: actions/upload-artifact@v4
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-        repository: goharbor/harbor-acceld
-        short-description:  ${{ github.event.repository.description }}
-        readme-filepath: ./README.md
+        name: digests-${{ env.PLATFORM_PAIR }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  release_image:
+    runs-on: ubuntu-latest
+    needs:
+      - build_image
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          repository: ${{ env.REGISTRY_IMAGE }}
+          short-description: "A general service to support image acceleration based on kinds of accelerator like Nydus"
+          readme-filepath: ./README.md
+
+  test_image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    needs:
+      - release_image
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Test Image
+        # Enable tty for docker
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker run -v $PWD/misc/config/config.nydus.yaml:/etc/acceld-config.yaml -d --rm -p 2077:2077 ${{ env.REGISTRY_IMAGE }} /etc/acceld-config.yaml
+          sleep 5
+          curl -f http://127.0.0.1:2077/api/v1/health
 
   release_binary:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
         echo "IMAGE_TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and Export to Docker
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: script/release/Dockerfile
@@ -39,13 +39,13 @@ jobs:
         curl -f http://127.0.0.1:2077/api/v1/health
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
     - name: Build and Push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
         file: script/release/Dockerfile

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Acceleration Service provides a general service to Harbor with the ability to au
 [eStargz](https://github.com/containerd/stargz-snapshotter), etc. drivers.
 
 [![Release Version](https://img.shields.io/github/v/release/goharbor/acceleration-service?style=flat)](https://github.com/goharbor/acceleration-service/releases)
+[![Docker Pulls](https://img.shields.io/docker/pulls/goharbor/harbor-acceld.svg)](https://hub.docker.com/r/goharbor/harbor-acceld/)
 [![Integration Test](https://github.com/goharbor/acceleration-service/actions/workflows/integration-test.yml/badge.svg?branch=main)](https://github.com/goharbor/acceleration-service/actions/workflows/integration-test.yml)
 [![Concurrent Test](https://github.com/goharbor/acceleration-service/actions/workflows/concurrent-test.yml/badge.svg?branch=main)](https://github.com/goharbor/acceleration-service/actions/workflows/concurrent-test.yml)
 [![Webhook Test](https://github.com/goharbor/acceleration-service/actions/workflows/webhook-test.yml/badge.svg?branch=main)](https://github.com/goharbor/acceleration-service/actions/workflows/webhook-test.yml)

--- a/script/release/Dockerfile
+++ b/script/release/Dockerfile
@@ -17,7 +17,7 @@ RUN sha256sum -c nydus-static-$NYDUS_VERSION-linux-amd64.tgz.sha256sum
 RUN tar xzvf nydus-static-$NYDUS_VERSION-linux-amd64.tgz && mv nydus-static/nydus-image /usr/local/bin/.
 
 # Build acceld image
-FROM photon:4.0
+FROM photon:5.0
 COPY --from=build /accel/acceld /accel/accelctl /usr/local/bin/nydus-image /usr/local/bin/
 COPY ./script/release/entrypoint.sh /entrypoint.sh
 

--- a/script/release/Dockerfile
+++ b/script/release/Dockerfile
@@ -1,20 +1,27 @@
 FROM golang:1.21.5 AS build
 
-ARG NYDUS_VERSION=v2.2.3
+ARG NYDUS_VERSION=v2.2.4
 
-ARG NYDUS_LINUX_AMD64_SHA256SUM="80b6e86f30a6f61958a878b705c5e36c7312cf0816e51c1e5e5f309931e28813"
+ARG NYDUS_LINUX_AMD64_SHA256SUM="2fbebb016d6fbbc52fd575be1753d063ca9ada19ff2db02d405955a53a077b51"
+
+ARG NYDUS_LINUX_ARM64_SHA256SUM="812398992eb8bb7993eb38a2bc6b222439037cfda9e7b6070937a7d55a2b189a"
 
 # Install acceld
 COPY ./ /accel
-RUN make -C /accel install-check-tools
-RUN make -C /accel check
-RUN make -C /accel
+RUN make -C /accel build
 
 # Install nydus component
-RUN wget https://github.com/dragonflyoss/image-service/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-linux-amd64.tgz
-RUN echo "$NYDUS_LINUX_AMD64_SHA256SUM  nydus-static-$NYDUS_VERSION-linux-amd64.tgz" | tee nydus-static-$NYDUS_VERSION-linux-amd64.tgz.sha256sum
-RUN sha256sum -c nydus-static-$NYDUS_VERSION-linux-amd64.tgz.sha256sum
-RUN tar xzvf nydus-static-$NYDUS_VERSION-linux-amd64.tgz && mv nydus-static/nydus-image /usr/local/bin/.
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    wget https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-linux-arm64.tgz \
+    echo "$NYDUS_LINUX_ARM64_SHA256SUM  nydus-static-$NYDUS_VERSION-linux-arm64.tgz" | tee nydus-static-$NYDUS_VERSION-linux-arm64.tgz.sha256sum; \
+    sha256sum -c nydus-static-$NYDUS_VERSION-linux-arm64.tgz.sha256sum; \
+    tar xzvf nydus-static-$NYDUS_VERSION-linux-arm64.tgz && mv nydus-static/nydus-image /usr/local/bin; \
+    else \
+    wget https://github.com/dragonflyoss/nydus/releases/download/$NYDUS_VERSION/nydus-static-$NYDUS_VERSION-linux-amd64.tgz \
+    echo "$NYDUS_LINUX_AMD64_SHA256SUM  nydus-static-$NYDUS_VERSION-linux-amd64.tgz" | tee nydus-static-$NYDUS_VERSION-linux-amd64.tgz.sha256sum; \
+    sha256sum -c nydus-static-$NYDUS_VERSION-linux-amd64.tgz.sha256sum; \
+    tar xzvf nydus-static-$NYDUS_VERSION-linux-amd64.tgz && mv nydus-static/nydus-image /usr/local/bin; \
+    fi
 
 # Build acceld image
 FROM photon:5.0


### PR DESCRIPTION
Since we have arm64 release binaries, we can also build arm64 images.

Ref: https://docs.docker.com/build/ci/github-actions/multi-platform.

1. set up `latest` version.
2. change the image tag from `v0.x.x` to `0.x.x`.
3. upload repo description.
4. support the `linux/arm64` image.

Test in my repo:
release action: https://github.com/Desiki-high/acceleration-service/actions/runs/7443126413
docker hub image: https://hub.docker.com/r/dingyadong/harbor-acceld and tag [0.2.8](https://hub.docker.com/layers/dingyadong/harbor-acceld/0.2.8/images/sha256-8f2030d5d04e72ffa328bcb8ef17625c5c33e602e780ee52f2dfcd5d2685a1e9?context=explore).