### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Get `accelctl` and `acceld` binaries from [acceleration-service release](https:/
     generate a base64 encoded auth string like this:
 
     ```bash
-    $ echo '<robot-name>:<robot-secret>' | base64
+    $ echo -n '<robot-name>:<robot-secret>' | base64
     ```
     > Note: the encoded auth string will be used in configuring acceleration service on the next step.
 


### PR DESCRIPTION
Fix generate secret. Withtout -n base64 will generate wrong code with new line string. I lost 2 hours for find this issue.

Signed-off-by: Peter G <contact@gawsoft.com