### PR TITLE
[nydus] Use artifactType instead of os.features

### DIFF
--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -352,7 +352,7 @@ func (d *Driver) makeManifestIndex(ctx context.Context, cs content.Store, oci, n
 		if desc.Platform == nil {
 			desc.Platform = &ocispec.Platform{}
 		}
-		desc.Platform.OSFeatures = []string{nydusutils.ManifestOSFeatureNydus}
+		desc.ArtifactType = nydusutils.ArtifactTypeNydusImage
 		nydusDescs[idx] = desc
 	}
 

--- a/pkg/driver/nydus/utils/constant.go
+++ b/pkg/driver/nydus/utils/constant.go
@@ -16,6 +16,7 @@ package utils
 
 const (
 	ManifestOSFeatureNydus   = "nydus.remoteimage.v1"
+	ArtifactTypeNydusImage   = "application/vnd.nydus.image.manifest.v1+json"
 	MediaTypeNydusBlob       = "application/vnd.oci.image.layer.nydus.blob.v1"
 	BootstrapFileNameInLayer = "image/image.boot"
 


### PR DESCRIPTION
The os.features field that gets added when creating index manifests in a merged-platform situation is causing issues with some registries like ECR as they don't accept this field despite being part of the OCI spec. Since the field is currently only supported by build tools and not by any runtime, we think it's fine to remove it and replace it by the `artifactType` field which is accepted by ECR.

That's technically a breaking change as tooling that was relying on this field would stop working so that might be worth a specific release note

cc @imeoer 