### PR TITLE
[nydus] Add empty layer in OCI image when merging platforms

### DIFF
--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -57,6 +57,8 @@ const (
 	annotationSourceDigest = "containerd.io/snapshot/nydus-source-digest"
 	// annotationSourceReference indicates the source OCI image reference name.
 	annotationSourceReference = "containerd.io/snapshot/nydus-source-reference"
+	// annotationEmptyLayer indicates that the layer is an empty layer added by nydus that won't change the final image's content.
+	annotationEmptyLayer = "containerd.io/snapshot/nydus-empty-layer"
 	// annotationFsVersion indicates the fs version (rafs v5/v6) of nydus image.
 	annotationFsVersion = "containerd.io/snapshot/nydus-fs-version"
 	// annotationBuilderVersion indicates the nydus builder (nydus-image) version.
@@ -487,9 +489,10 @@ func PrependEmptyLayer(ctx context.Context, cs content.Store, manifestDesc ocisp
 	}
 	emptyDescriptorBytes := generateDockerEmptyLayer()
 	emptyDescriptor := ocispec.Descriptor{
-		MediaType: emptyLayerMediaType,
-		Digest:    digest.FromBytes(emptyDescriptorBytes),
-		Size:      int64(len(emptyDescriptorBytes)),
+		Annotations: map[string]string{annotationEmptyLayer: "true"},
+		MediaType:   emptyLayerMediaType,
+		Digest:      digest.FromBytes(emptyDescriptorBytes),
+		Size:        int64(len(emptyDescriptorBytes)),
 	}
 
 	manifest.Layers = append([]ocispec.Descriptor{emptyDescriptor}, manifest.Layers...)

--- a/pkg/driver/nydus/nydus_test.go
+++ b/pkg/driver/nydus/nydus_test.go
@@ -1,0 +1,310 @@
+package nydus
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/plugins/content/local"
+	nydusutils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+	"github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testManifest struct {
+	name               string
+	mediaType          string
+	layers             []ocispec.Descriptor
+	config             ocispec.Image
+	configMediaType    string
+	expectedLayerCount int
+}
+
+func Test_PrependEmptyLayer(t *testing.T) {
+	tests := []testManifest{
+		{
+			name:      "oci_manifest_single_layer",
+			mediaType: ocispec.MediaTypeImageManifest,
+			layers: []ocispec.Descriptor{
+				{
+					MediaType: ocispec.MediaTypeImageLayerGzip,
+					Digest:    "sha256:existing-layer-digest",
+					Size:      1000,
+				},
+			},
+			config: ocispec.Image{
+				RootFS: ocispec.RootFS{
+					Type:    "layers",
+					DiffIDs: []digest.Digest{"sha256:existing-diff-id"},
+				},
+				History: []ocispec.History{
+					{
+						CreatedBy: "test layer",
+					},
+				},
+			},
+			configMediaType:    ocispec.MediaTypeImageConfig,
+			expectedLayerCount: 2,
+		},
+		{
+			name:      "oci_manifest_multiple_layers",
+			mediaType: ocispec.MediaTypeImageManifest,
+			layers: []ocispec.Descriptor{
+				{
+					MediaType: ocispec.MediaTypeImageLayerGzip,
+					Digest:    "sha256:layer1-digest",
+					Size:      1000,
+				},
+				{
+					MediaType: ocispec.MediaTypeImageLayerGzip,
+					Digest:    "sha256:layer2-digest",
+					Size:      2000,
+				},
+			},
+			config: ocispec.Image{
+				RootFS: ocispec.RootFS{
+					Type:    "layers",
+					DiffIDs: []digest.Digest{"sha256:diff-id1", "sha256:diff-id2"},
+				},
+				History: []ocispec.History{
+					{
+						CreatedBy: "layer 1",
+					},
+					{
+						CreatedBy: "layer 2",
+					},
+				},
+			},
+			configMediaType:    ocispec.MediaTypeImageConfig,
+			expectedLayerCount: 3,
+		},
+		{
+			name:      "oci_manifest_no_layers",
+			mediaType: ocispec.MediaTypeImageManifest,
+			layers:    []ocispec.Descriptor{},
+			config: ocispec.Image{
+				RootFS: ocispec.RootFS{
+					Type:    "layers",
+					DiffIDs: []digest.Digest{},
+				},
+				History: []ocispec.History{},
+			},
+			configMediaType:    ocispec.MediaTypeImageConfig,
+			expectedLayerCount: 1,
+		},
+		{
+			name:      "docker_manifest_single_layer",
+			mediaType: images.MediaTypeDockerSchema2Manifest,
+			layers: []ocispec.Descriptor{
+				{
+					MediaType: images.MediaTypeDockerSchema2LayerGzip,
+					Digest:    "sha256:docker-layer-digest",
+					Size:      1500,
+				},
+			},
+			config: ocispec.Image{
+				RootFS: ocispec.RootFS{
+					Type:    "layers",
+					DiffIDs: []digest.Digest{"sha256:docker-diff-id"},
+				},
+				History: []ocispec.History{
+					{
+						CreatedBy: "docker layer",
+					},
+				},
+			},
+			configMediaType:    images.MediaTypeDockerSchema2Config,
+			expectedLayerCount: 2,
+		},
+		{
+			name:      "docker_manifest_multiple_layers",
+			mediaType: images.MediaTypeDockerSchema2Manifest,
+			layers: []ocispec.Descriptor{
+				{
+					MediaType: images.MediaTypeDockerSchema2LayerGzip,
+					Digest:    "sha256:docker-layer1-digest",
+					Size:      1000,
+				},
+				{
+					MediaType: images.MediaTypeDockerSchema2LayerGzip,
+					Digest:    "sha256:docker-layer2-digest",
+					Size:      2000,
+				},
+			},
+			config: ocispec.Image{
+				RootFS: ocispec.RootFS{
+					Type:    "layers",
+					DiffIDs: []digest.Digest{"sha256:docker-diff-id1", "sha256:docker-diff-id2"},
+				},
+				History: []ocispec.History{
+					{
+						CreatedBy: "docker layer 1",
+					},
+					{
+						CreatedBy: "docker layer 2",
+					},
+				},
+			},
+			configMediaType:    images.MediaTypeDockerSchema2Config,
+			expectedLayerCount: 3,
+		},
+		{
+			name:      "docker_manifest_no_layers",
+			mediaType: images.MediaTypeDockerSchema2Manifest,
+			layers:    []ocispec.Descriptor{},
+			config: ocispec.Image{
+				RootFS: ocispec.RootFS{
+					Type:    "layers",
+					DiffIDs: []digest.Digest{},
+				},
+				History: []ocispec.History{},
+			},
+			configMediaType:    images.MediaTypeDockerSchema2Config,
+			expectedLayerCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tempDir := t.TempDir()
+			defer func() {
+				if err := os.RemoveAll(tempDir); err != nil {
+					t.Logf("failed to cleanup temp dir: %v", err)
+				}
+			}()
+
+			// Create content store
+			cs, err := local.NewStore(tempDir)
+			require.NoError(t, err, "failed to create content store")
+
+			// Setup test data
+			configDesc, err := createConfigBlob(ctx, cs, tt.configMediaType, tt.config)
+			require.NoError(t, err, "failed to create config blob")
+
+			manifestDesc, err := createManifestBlob(ctx, cs, tt.mediaType, tt.layers, *configDesc)
+			require.NoError(t, err, "failed to create manifest blob")
+
+			// Test PrependEmptyLayer
+			newManifestDesc, err := PrependEmptyLayer(ctx, cs, *manifestDesc)
+			require.NoError(t, err, "PrependEmptyLayer should succeed")
+
+			// Verify results
+			verifyPrependResults(ctx, t, cs, *manifestDesc, newManifestDesc, tt.config, tt.expectedLayerCount)
+		})
+	}
+}
+
+func createConfigBlob(ctx context.Context, cs content.Store, mediaType string, config ocispec.Image) (*ocispec.Descriptor, error) {
+	configDesc, configBytes, err := nydusutils.MarshalToDesc(config, mediaType)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal config")
+	}
+
+	err = content.WriteBlob(ctx, cs, configDesc.Digest.String(), bytes.NewReader(configBytes), *configDesc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to write config blob")
+	}
+	return configDesc, nil
+}
+
+func createManifestBlob(ctx context.Context, cs content.Store, mediaType string, layers []ocispec.Descriptor, configDesc ocispec.Descriptor) (*ocispec.Descriptor, error) {
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: mediaType,
+		Config:    configDesc,
+		Layers:    layers,
+	}
+
+	manifestDesc, manifestBytes, err := nydusutils.MarshalToDesc(manifest, mediaType)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to marshal manifest")
+	}
+
+	err = content.WriteBlob(ctx, cs, manifestDesc.Digest.String(), bytes.NewReader(manifestBytes), *manifestDesc)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to write manifest blob")
+	}
+	return manifestDesc, nil
+}
+
+func verifyPrependResults(ctx context.Context, t *testing.T, cs content.Store, originalManifestDesc, newManifestDesc ocispec.Descriptor, originalConfig ocispec.Image, expectedLayerCount int) {
+	// Verify manifest descriptor changes
+	assert.Equal(t, originalManifestDesc.MediaType, newManifestDesc.MediaType, "media type should remain unchanged")
+	assert.Equal(t, originalManifestDesc.Digest.String(), newManifestDesc.Annotations[annotationSourceDigest], "source digest annotation should match original manifest digest")
+
+	// Read the new manifest
+	newManifestBytes, err := content.ReadBlob(ctx, cs, newManifestDesc)
+	require.NoError(t, err, "failed to read new manifest")
+
+	var newManifest ocispec.Manifest
+	require.NoError(t, json.Unmarshal(newManifestBytes, &newManifest), "failed to unmarshal new manifest")
+
+	assert.Len(t, newManifest.Layers, expectedLayerCount, "layer count should match expected")
+
+	// Verify empty layer is first
+	emptyLayer := newManifest.Layers[0]
+	expectedEmptyDigest := "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
+	assert.Equal(t, expectedEmptyDigest, emptyLayer.Digest.String(), "empty layer digest should match expected")
+	assert.Equal(t, int64(32), emptyLayer.Size, "empty layer size should be 32 bytes")
+
+	// Verify media types based on the original manifest type
+	var expectedEmptyLayerMediaType, expectedconfigDescriptorMediaType string
+	switch originalManifestDesc.MediaType {
+	case ocispec.MediaTypeImageManifest:
+		expectedEmptyLayerMediaType = ocispec.MediaTypeImageLayerGzip
+		expectedconfigDescriptorMediaType = ocispec.MediaTypeImageConfig
+	case images.MediaTypeDockerSchema2Manifest, images.MediaTypeDockerSchema1Manifest:
+		expectedEmptyLayerMediaType = images.MediaTypeDockerSchema2LayerGzip
+		expectedconfigDescriptorMediaType = images.MediaTypeDockerSchema2Config
+	}
+	assert.Equal(t, expectedEmptyLayerMediaType, emptyLayer.MediaType, "empty layer media type should match manifest type")
+	assert.Equal(t, expectedconfigDescriptorMediaType, newManifest.Config.MediaType, "config media type should match manifest type")
+
+	assert.Equal(t, originalManifestDesc.Digest.String(), newManifest.Annotations[annotationSourceDigest],
+		"source digest annotation should match original manifest digest")
+
+	// Read and verify new config
+	newConfigBytes, err := content.ReadBlob(ctx, cs, newManifest.Config)
+	require.NoError(t, err, "failed to read new config")
+
+	var newConfig ocispec.Image
+	require.NoError(t, json.Unmarshal(newConfigBytes, &newConfig), "failed to unmarshal new config")
+
+	expectedDiffIDCount := expectedLayerCount
+	assert.Len(t, newConfig.RootFS.DiffIDs, expectedDiffIDCount, "diff IDs count should increase by 1")
+
+	// Verify empty diff ID is first and matches constant
+	assert.Equal(t, emptyTarGzipUnpackedDigest, newConfig.RootFS.DiffIDs[0],
+		"first diff ID should match empty tar gzip unpacked digest constant")
+
+	expectedHistoryCount := len(originalConfig.History) + 1
+	assert.Len(t, newConfig.History, expectedHistoryCount, "history count should increase by 1")
+
+	// Verify empty layer history entry
+	emptyHistory := newConfig.History[0]
+	assert.Equal(t, "Nydus Converter", emptyHistory.CreatedBy, "empty layer should be created by Nydus Converter")
+	assert.Equal(t, "Nydus Empty Layer", emptyHistory.Comment, "empty layer comment should be correct")
+}
+
+func Test_generateDockerEmptyLayer(t *testing.T) {
+	emptyLayer := generateDockerEmptyLayer()
+
+	expectedSize := 32
+	expectedDigest := "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
+
+	assert.Len(t, emptyLayer, expectedSize, "empty layer should be 32 bytes")
+
+	actualDigest := digest.FromBytes(emptyLayer).String()
+	assert.Equal(t, expectedDigest, actualDigest, "empty layer digest should match expected")
+}

--- a/pkg/driver/nydus/nydus_test.go
+++ b/pkg/driver/nydus/nydus_test.go
@@ -257,6 +257,7 @@ func verifyPrependResults(ctx context.Context, t *testing.T, cs content.Store, o
 	expectedEmptyDigest := "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1"
 	assert.Equal(t, expectedEmptyDigest, emptyLayer.Digest.String(), "empty layer digest should match expected")
 	assert.Equal(t, int64(32), emptyLayer.Size, "empty layer size should be 32 bytes")
+	assert.Equal(t, "true", emptyLayer.Annotations[annotationEmptyLayer], "empty layer annotation should be set to true")
 
 	// Verify media types based on the original manifest type
 	var expectedEmptyLayerMediaType, expectedconfigDescriptorMediaType string


### PR DESCRIPTION
Add an empty tar.gz layer at the beginning of the OCI image that's referrenced in the nydus merged-manifest compared to the original OCI one. This empty layer, being the first layer, will force the OCI image to have a completely different chainID from its original counterpart. This is done so that containerd and other runtimes don't try to reuse the OCI layers for other images that share layers with the original OCI variant. The drawback being that nydus-merged images can't share layers with pure OCI images when they are pulled on non-nydus clients.

The choice to use an empty tar.gz layer as the new first layer is because:
- this is a format understood by every runtime (on the other hand, docker doesn't understand layers that use `application/vnd.oci.empty.v1+json`)
- an empty layer won't change the unpacked digest of the final image
- it shouldn't be possible for a regular image (not built using nydus merge-manifest) to start wtih an empty tar.gzip. That's because they would need to be based on `scratch` and any layer they would add will necessary change something on the filesystem so it won't be an empty change


## Testing

Testing this change should show that the final nydus image doesn't cause layer reuse issues:

- I built 2 images with shared layers:
image-a:
```
FROM ubuntu:20.04

RUN echo "This is a shared base layer" > /shared-content.txt && \
    echo "Common configuration" > /etc/shared-config.conf && \
    mkdir -p /shared-data

RUN echo "#!/bin/bash" > /usr/local/bin/shared-script.sh && \
    echo "echo 'This script is in the shared layers'" >> /usr/local/bin/shared-script.sh && \
    chmod +x /usr/local/bin/shared-script.sh

WORKDIR /app
```
```
docker buildx build --push . -f a.dockerfile -t localhost:5000/image-a
```

image-b:
```
FROM ubuntu:20.04

RUN echo "This is a shared base layer" > /shared-content.txt && \
    echo "Common configuration" > /etc/shared-config.conf && \
    mkdir -p /shared-data

RUN echo "#!/bin/bash" > /usr/local/bin/shared-script.sh && \
    echo "echo 'This script is in the shared layers'" >> /usr/local/bin/shared-script.sh && \
    chmod +x /usr/local/bin/shared-script.sh

WORKDIR /app

# NYDUS-SPECIFIC content (should NOT appear in OCI image)
RUN echo "This content belongs ONLY to the nydus image" > /nydus-specific.txt && \
    echo "NYDUS_APP=true" > /etc/nydus-env.conf && \
    mkdir -p /nydus-only-data && \
    echo "nydus-secret-data" > /nydus-only-data/secret.txt

# More NYDUS-SPECIFIC content
RUN echo "#!/bin/bash" > /usr/local/bin/nydus-only-script.sh && \
    echo "echo 'This script should ONLY be in nydus image'" >> /usr/local/bin/nydus-only-script.sh && \
    echo "echo 'If you see this in OCI image, there is a bug!'" >> /usr/local/bin/nydus-only-script.sh && \
    chmod +x /usr/local/bin/nydus-only-script.sh

CMD ["/usr/local/bin/nydus-only-script.sh"]
```
```
docker buildx build --push . -f b.dockerfile -t localhost:5000/image-b
```

Converting image-b to nydus with the current release of nydusify
```
nydusify convert --source localhost:5000/image-b:latest --target-suffix -nydus-broken --merge-platform
```
Then pulling both images with containerd:
```
$ crictl pull localhost:5000/image-b:latest-nydus-broken
Image is up to date for sha256:2a4a57339629c3a53d5d044da23ab0979d166f849ac28520eb3af1e7c2832855

$ crictl pull localhost:5000/image-a:latest
Image is up to date for sha256:d05f40f709a10b870d375bae75fd943a703bd887a455578a3e3bb29c304f0fa8

$ ctr snapshots tree
 sha256:470b66ea5123c93b0d5606e4213bf9e47d3d426b640d32472e4ac213186c4bb6
  \_ sha256:034b1b090fefd084928e43e3a32d024041ffa59f8307a7513a0b46c53a3a31c3
    \_ sha256:c65e7e76437bad248b44d8ea4196ab440cc5b231b7c38809e00fce0ac37f8cd7
      \_ sha256:9a9712ef67bac530a8428adb7e4e0ae4e0fa23602f0f14e19bd087961614e97f
        \_ sha256:c930a734441e91855717e2b7c1bdf9fc2ec13296334f7fa0ea86063342941122
          \_ sha256:06cfbab4be39d591fd0542df0a3e026c888f8d720d95ccb7a80ad014b685da70
```
The final result is that both images share layers

On the other hand, if we use a nydusify built with these changes:
```
./cmd/nydusify convert --source localhost:5000/image-b:latest --target-suffix -nydus --merge-platform
```
When we pull both images
```
$ crictl pull localhost:5000/image-b:latest-nydus
Image is up to date for sha256:a2972175f46d9015bdbc6d92fee2f2f090b8efecaaf418c6b0a5ab577d862c5f

$ crictl pull localhost:5000/image-a:latest
Image is up to date for sha256:d05f40f709a10b870d375bae75fd943a703bd887a455578a3e3bb29c304f0fa8

$ ctr snapshots tree
 sha256:470b66ea5123c93b0d5606e4213bf9e47d3d426b640d32472e4ac213186c4bb6
  \_ sha256:034b1b090fefd084928e43e3a32d024041ffa59f8307a7513a0b46c53a3a31c3
    \_ sha256:c65e7e76437bad248b44d8ea4196ab440cc5b231b7c38809e00fce0ac37f8cd7
      \_ sha256:9a9712ef67bac530a8428adb7e4e0ae4e0fa23602f0f14e19bd087961614e97f
 sha256:5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef
  \_ sha256:d278c8223e446d9d48226816284703bc9f5bc740596f13cfaee8b0f1926d475f
    \_ sha256:0d2b93084b15a90b4094675332e316d1f03ed7e347db966ba440c97ec7ec39d2
      \_ sha256:1c7c78e8f561e7aeb383e2ac5498946db43a0042ab1d74ad12b4fe94308b378c
        \_ sha256:ab6d7b03ec1e9b7a565027ad657af410183f9a1a10be8e24fe30b430f11d10d1
          \_ sha256:c9d67654a4c9f3e9e9c2f35be0cda03b206fa45cdf7085766d648c00ba4d3d24
            \_ sha256:f5d2915eb668300ef855de26612e74001575510fbd99017d6b7cec8d0504a4fa
```

The first tree corresponds to image-a (sha match with above)
The second tree is the nydus image which now has different digests and 1 additional layer whose chainID `5f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef` match the value we expect from the empty tar.gz