### PR TITLE
[nydus] Remove old config's reference in config descriptor's annotations when adding empty layer

### DIFF
--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -515,10 +515,6 @@ func PrependEmptyLayer(ctx context.Context, cs content.Store, manifestDesc ocisp
 	if err != nil {
 		return ocispec.Descriptor{}, errors.Wrap(err, "marshal modified config")
 	}
-	if newConfigDesc.Annotations == nil {
-		newConfigDesc.Annotations = map[string]string{}
-	}
-	newConfigDesc.Annotations[annotationSourceDigest] = manifest.Config.Digest.String()
 
 	manifest.Config = *newConfigDesc
 	newManifestDesc, newManifestBytes, err := nydusutils.MarshalToDesc(manifest, manifest.MediaType)


### PR DESCRIPTION
Trying to push a manifest with an added empty layer to ECR currently fails because the manifest's config descriptor has an annotation field with a referrence to the old config digest. 

The failure is ` Invalid parameter at 'ImageManifest' failed to satisfy constraint: 'Invalid JSON syntax'`. 

This field should be accepted by ECR because it's present in the [spec](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#properties) but since there is no hard need to keep it as an annotation on the config descriptor, this PR removes the annotation entirely since the original config can still be discovered by finding the original OCI manifest using the digest stored in the new manifest annotations.