### PR TITLE
[adapter] Use context without cancel for GC

### DIFF
--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -137,7 +137,7 @@ func (adp *LocalAdapter) Convert(ctx context.Context, source string) (*converter
 		}
 		return nil, err
 	}
-	go adp.content.GC(ctx, adp.content.Threshold)
+	go adp.content.GC(context.WithoutCancel(ctx), adp.content.Threshold)
 	return metric, nil
 }
 


### PR DESCRIPTION
The GC triggered in a goroutine after the Convert operation is done was called with the same context passed down. However, when the convert action is called synchronously (accelctl --sync), the associated context is canceled when the sync operation is completed. Since the GC was run after, it was failing with a `context canceled` error. To solve this, we now remove the `cancel` from the context passed down to the GC.


The issue was easy to reproduce:
- configure a low GC threshold in the acceld config 
```
  gcpolicy:
      # size threshold that triggers GC, the oldest used blobs will be reclaimed if exceeds the size.
      threshold: 5MB
```
- trigger a sync job with accelctl:
```
$ accelctl task create --sync localhost:5000/busybox:latest
INFO[2025-10-10T14:09:24.510985013+02:00] Version: e62d1e0.m e62d1e0b038a1be66eeae63e136375c0d193b858.20251010.1207
INFO[2025-10-10T14:09:24.511218031+02:00] Waiting task to be completed...
INFO[2025-10-10T14:09:25.975216651+02:00] Task has been completed.
```
- GC fail 
```
./acceld --config ./misc/config/config.nydus.yaml
INFO[2025-10-10T14:05:21.375447667+02:00] Version: e62d1e0.m e62d1e0b038a1be66eeae63e136375c0d193b858.20251010.1203
INFO[2025-10-10T14:05:21.394133827+02:00] [API] HTTP server started on 127.0.0.1:2077
INFO[2025-10-10T14:05:23.534144334+02:00] received webhook request from 127.0.0.1:45718  module=api
INFO[2025-10-10T14:05:23.538956121+02:00] pulling image localhost:5000/busybox:latest   module=converter
INFO[2025-10-10T14:05:23.542408656+02:00] fetch failed                                  error="failed to do request: Head \"https://localhost:5000/v2/busybox/manifests/latest\": http: server gave HTTP response toHTTPS client" host="localhost:5000"
INFO[2025-10-10T14:05:23.542514286+02:00] try to pull with plain HTTP for localhost:5000/busybox:latest  module=converter
INFO[2025-10-10T14:05:23.701416651+02:00] pulled image localhost:5000/busybox:latest , elapse 141.679899ms  module=converter
INFO[2025-10-10T14:05:23.701488084+02:00] converting image localhost:5000/busybox:latest  module=converter
INFO[2025-10-10T14:05:24.637993152+02:00] converted image localhost:5000/busybox:latest-nydus , elapse 910.5332ms  module=converter
INFO[2025-10-10T14:05:24.638029898+02:00] pushing image localhost:5000/busybox:latest-nydus  module=converter
WARN[2025-10-10T14:05:24.661200121+02:00] reference for unknown type: application/vnd.nydus.image.config.v1+json  digest="sha256:b49c4b4c6bf0d17bc0fa94367d6520ccd33c1cdb18f5ab77acf555562499f7df" mediatype=application/vnd.nydus.image.config.v1+json size=536
WARN[2025-10-10T14:05:24.670307039+02:00] reference for unknown type: application/vnd.nydus.image.config.v1+json  digest="sha256:bd7db24b9e0bf3ec3f50ad3a3fdfa888a47fb6405f122516509d18f391ed0500" mediatype=application/vnd.nydus.image.config.v1+json size=521
INFO[2025-10-10T14:05:24.82021891+02:00] pushed image localhost:5000/busybox:latest-nydus, elapse 182.169849ms  module=converter
50000000
80
2904191958
INFO[2025-10-10T14:05:24.825369975+02:00] POST /api/v1/conversions?sync=true 200 1.291169754s 102>5bytes 127.0.0.1  module=api
ERRO[2025-10-10T14:05:25.184900059+02:00] gc: context canceled
```