### PR TITLE
[content] Fix nil pointer exception in cleanLeases

### DIFF
--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -176,7 +176,13 @@ func (content *Content) cleanLeases(ctx context.Context, size int64) error {
 			return err
 		}
 		if err := content.db.View(func(tx *bolt.Tx) error {
-			blobsize, err := blobSize(getBlobsBucket(tx).Bucket([]byte(digest)))
+			bucket := getBlobsBucket(tx)
+			// if can't find blob bucket, it means content store is empty
+			if bucket == nil {
+				return nil
+			}
+
+			blobsize, err := blobSize(bucket.Bucket([]byte(digest)))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
I'm sometimes seeing `nil pointer exception` errors in the GC `cleanLeases` function. I'm not sure why it happens and I haven't been able to reproduce it reliably but in any case, I feel like we should avoid having possible `nil` pointer issues.

For now, I return nil error if the bucket is nil but we can also a more direct error if you prefer.