### PR TITLE
[nydus] Remove timestamp in empty layer history

### DIFF
--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -20,7 +20,6 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
-	"time"
 
 	"fmt"
 
@@ -503,9 +502,8 @@ func PrependEmptyLayer(ctx context.Context, cs content.Store, manifestDesc ocisp
 	// Add an empty diff_id at the beginning of the config
 	config.RootFS.DiffIDs = append([]digest.Digest{emptyTarGzipUnpackedDigest}, config.RootFS.DiffIDs...)
 	// Rewrite history to add an entry for the empty layer
-	createdTime := time.Now()
+	// No timestamp is added to avoid changing the config digest between 2 conversions of the same image
 	emptyLayerHistory := ocispec.History{
-		Created:   &createdTime,
 		CreatedBy: "Nydus Converter",
 		Comment:   "Nydus Empty Layer",
 	}


### PR DESCRIPTION
This only impacts builds with `mergeManifest`.

While having a timestamp gives an interesting information on when the nydus image was built, the consequence is that every reconversion of the same image will yield a different digest because the timestamp changed which is a nightmare from a caching perspective. To avoid this, the timestamp is removed from the empty layer to ensure a consistent digest.


Example for the issue:
2 images built at different timestamps have a different config digest:
```
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:3b5fb72ccb241d4d5a8642360a2c15584668bf268ea55b5b6b9cb67fd2a99ffd",
    "size": 726,
    "annotations": {
      "containerd.io/snapshot/nydus-source-digest": "sha256:0ed463b26daee791b094dc3fff25edb3e79f153d37d274e5c2936923c38dac2b"
    }
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
      "size": 32,
      "annotations": {
        "containerd.io/snapshot/nydus-empty-layer": "true"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar",
      "digest": "sha256:80e840de630d08a6a1e0ee30e7c8378cf1ed6a424315d7e437f54780aee6bf5a",
      "size": 4669440
    }
  ],
  "annotations": {
    "containerd.io/snapshot/nydus-source-digest": "sha256:ea6157971956293af8a6a32929c239a73287b158110053b3560103b77a4f9124"
  }
}
```

and 
```
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.oci.image.config.v1+json",
    "digest": "sha256:5d69623c850f1475d66b446ae05f56ed5c4c4766c6101160f0bad90e7a084200",
    "size": 726,
    "annotations": {
      "containerd.io/snapshot/nydus-source-digest": "sha256:0ed463b26daee791b094dc3fff25edb3e79f153d37d274e5c2936923c38dac2b"
    }
  },
  "layers": [
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
      "size": 32,
      "annotations": {
        "containerd.io/snapshot/nydus-empty-layer": "true"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.layer.v1.tar",
      "digest": "sha256:80e840de630d08a6a1e0ee30e7c8378cf1ed6a424315d7e437f54780aee6bf5a",
      "size": 4669440
    }
  ],
  "annotations": {
    "containerd.io/snapshot/nydus-source-digest": "sha256:ea6157971956293af8a6a32929c239a73287b158110053b3560103b77a4f9124"
  }
}
```

Looking at the config objects, the only difference is the timestamp:
```
$ diff config1 config2
22c22
<       "created": "2025-10-21T19:04:33.020386798+02:00",
---
>       "created": "2025-10-21T19:02:24.778739288+02:00",
```