### PR TITLE
[ci] Fix release artifact job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: harbor-acceld-artifacts
+          name: harbor-acceld-artifacts-${{ matrix.arch }}
           path: |
             ${{ env.OUTPUT_DIR }}
 
@@ -167,7 +167,8 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: harbor-acceld-artifacts
+          pattern: harbor-acceld-artifacts-*
+          merge-multiple: true
           path: |
             ${{ env.OUTPUT_DIR }}
       - name: Create Release


### PR DESCRIPTION
Since migrating to actions/upload-artifact@v4 from actions/upload-artifact@v3, the release job is failing because v4 had a breaking change where it isn't possible to have multiple artifacts with the same name anymore. The migration path highlighted here https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact indicates that different names should be used and be downloaded in the same directory using `merge-multiple`.


I tested by creating a v0.0.0 tag in my fork and it created a release with the expected binaries present 
<img width="2474" height="1340" alt="image" src="https://github.com/user-attachments/assets/2ae860bf-1c75-4219-a82f-8eb3a2ab32b3" />
