### PR TITLE
chore(deps): bump nydus-snapshotter to v0.15.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd/v2 v2.0.2
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/log v0.1.0
-	github.com/containerd/nydus-snapshotter v0.15.3
+	github.com/containerd/nydus-snapshotter v0.15.7
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/stargz-snapshotter v0.16.3
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/containerd/nydus-snapshotter v0.15.3 h1:dgeroRQnfgpTgnw2MgsWZCHr71bDbZhlH7cHD4FebHI=
-github.com/containerd/nydus-snapshotter v0.15.3/go.mod h1:eRJqnxQDr48HNop15kZdLZpFF5B6vf6Q11Aq1K0E4Ms=
+github.com/containerd/nydus-snapshotter v0.15.7 h1:0/IVOpqM3TClKjzGRhmT3nq38IIZ62eACxGxTKcDk/0=
+github.com/containerd/nydus-snapshotter v0.15.7/go.mod h1:eRJqnxQDr48HNop15kZdLZpFF5B6vf6Q11Aq1K0E4Ms=
 github.com/containerd/platforms v1.0.0-rc.1 h1:83KIq4yy1erSRgOVHNk1HYdPvzdJ5CnsWaRoJX4C41E=
 github.com/containerd/platforms v1.0.0-rc.1/go.mod h1:J71L7B+aiM5SdIEqmd9wp6THLVRzJGXfNuWCZCllLA4=
 github.com/containerd/plugin v1.0.0 h1:c8Kf1TNl6+e2TtMHZt+39yAPDbouRH9WAToRjex483Y=


### PR DESCRIPTION
## Description

Upgrade nydus-snapshotter to the latest version v0.15.7 to leverage recent improvements and bug fixes.

## What's Updated

- Dependency version: `github.com/containerd/nydus-snapshotter v0.15.7`
- Files modified: `go.mod`, `go.sum`

## Verification

- ✅ `go mod tidy` completes successfully
- ✅ `go build ./...` compiles without errors
- ✅ All existing tests pass