### PR TITLE
[remote] Fix ReadAt to comply with io.ReaderAt semantics

### DIFF
--- a/pkg/remote/ported.go
+++ b/pkg/remote/ported.go
@@ -220,7 +220,7 @@ func (hrs *httpReadSeeker) ReadAt(p []byte, offset int64) (n int, err error) {
 	if _, err = hrs.Seek(offset, io.SeekStart); err != nil {
 		return 0, err
 	}
-	return hrs.Read(p)
+	return io.ReadFull(hrs, p)
 }
 
 func (hrs *httpReadSeeker) Size() int64 {


### PR DESCRIPTION
## Description

Fixed `httpReadSeeker.ReadAt` to comply with `io.ReaderAt` interface by using `io.ReadFull`.

## Related Issue

Fixes #361