### PR TITLE
Support single manifest cache images

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -251,36 +251,61 @@ func (rc *RemoteCache) Fetch(ctx context.Context, platformMC platforms.MatchComp
 			if err != nil {
 				return nil, errors.Wrap(err, "read remote cache manifest")
 			}
-			if targetManifest.Annotations[LayerAnnotationCacheVersion] != rc.version {
-				logrus.WithError(err).Warnf("ignore cache %s, unmatched version: %s, expected: %s", rc.Ref,
-					targetManifest.Annotations[LayerAnnotationCacheVersion], rc.version)
-				continue
-			}
 			targetManifests = append(targetManifests, targetManifest)
 		}
 		for _, manifest := range targetManifests {
-			for _, targetDesc := range manifest.Layers {
-				sourceDigest := digest.Digest(targetDesc.Annotations[nydusify.LayerAnnotationNydusSourceDigest])
-				if err := sourceDigest.Validate(); err != nil {
-					logrus.WithError(err).Warnf("invalid cache layer digest record: %s", sourceDigest)
-					continue
-				}
-				reader, sourceDesc, err := fetcher.(remotes.FetcherByDigest).FetchByDigest(ctx, sourceDigest)
-				if err != nil {
-					return nil, errors.Wrap(err, "read remote cache manifest")
-				}
-				reader.Close()
-				if targetDesc.Annotations == nil {
-					targetDesc.Annotations = map[string]string{}
-				}
-				targetDesc.Annotations[nydusify.LayerAnnotationUncompressed] = string(targetDesc.Digest)
-				rc.set(sourceDesc, targetDesc)
+			if err := rc.importManifestRecords(ctx, fetcher, manifest); err != nil {
+				return nil, err
 			}
 		}
 		return manifestIndexDesc, nil
+	case images.MediaTypeDockerSchema2Manifest, ocispec.MediaTypeImageManifest:
+		manifest := ocispec.Manifest{}
+		if err = json.Unmarshal(mBytes, &manifest); err != nil {
+			return nil, errors.Wrap(err, "unmarshal remote cache manifest")
+		}
+		if err = content.WriteBlob(ctx, rc.provider.ContentStore(), rc.Ref, bytes.NewReader(mBytes), desc); err != nil {
+			return nil, errors.Wrap(err, "write remote cache manifest")
+		}
+		if err := rc.importManifestRecords(ctx, fetcher, manifest); err != nil {
+			return nil, err
+		}
+		return &desc, nil
 	default:
 		return nil, fmt.Errorf("unsupported cache image mediatype %s", desc.MediaType)
 	}
+}
+
+func (rc *RemoteCache) importManifestRecords(ctx context.Context, fetcher remotes.Fetcher, manifest ocispec.Manifest) error {
+	if manifest.Annotations[LayerAnnotationCacheVersion] != rc.version {
+		logrus.Warnf("ignore cache %s, unmatched version: %s, expected: %s", rc.Ref,
+			manifest.Annotations[LayerAnnotationCacheVersion], rc.version)
+		return nil
+	}
+
+	fetcherByDigest, ok := fetcher.(remotes.FetcherByDigest)
+	if !ok {
+		return errors.New("remote cache fetcher does not support fetch by digest")
+	}
+
+	for _, targetDesc := range manifest.Layers {
+		sourceDigest := digest.Digest(targetDesc.Annotations[nydusify.LayerAnnotationNydusSourceDigest])
+		if err := sourceDigest.Validate(); err != nil {
+			logrus.WithError(err).Warnf("invalid cache layer digest record: %s", sourceDigest)
+			continue
+		}
+		reader, sourceDesc, err := fetcherByDigest.FetchByDigest(ctx, sourceDigest)
+		if err != nil {
+			return errors.Wrap(err, "read remote cache manifest")
+		}
+		reader.Close()
+		if targetDesc.Annotations == nil {
+			targetDesc.Annotations = map[string]string{}
+		}
+		targetDesc.Annotations[nydusify.LayerAnnotationUncompressed] = string(targetDesc.Digest)
+		rc.set(sourceDesc, targetDesc)
+	}
+	return nil
 }
 
 // Push merges local and remote cache records, then push cache manifest to remote registry.
@@ -290,70 +315,63 @@ func (rc *RemoteCache) Push(ctx context.Context, orgDesc, newDesc *ocispec.Descr
 	if err != nil && !errors.Is(err, ctrErrdefs.ErrNotFound) {
 		return err
 	}
-	cacheIndex, err := rc.update(ctx, orgDesc, newDesc, cacheDesc, platformMC)
+	cacheDesc, manifests, err := rc.update(ctx, orgDesc, newDesc, cacheDesc, platformMC)
 	if err != nil {
 		return err
 	}
-	for _, manifest := range cacheIndex.Manifests {
+	for _, manifest := range manifests {
 		if err := rc.provider.Push(ctx, manifest, rc.Ref); err != nil {
 			return err
 		}
 	}
-	manifestIndexDesc, manifestIndexBytes, err := nydusutils.MarshalToDesc(*cacheIndex, ocispec.MediaTypeImageIndex)
-	if err != nil {
-		return errors.Wrap(err, "marshal remote cache manifest index")
-	}
-	if err = content.WriteBlob(ctx, rc.provider.ContentStore(), rc.Ref, bytes.NewReader(manifestIndexBytes), *manifestIndexDesc); err != nil {
-		return errors.Wrap(err, "write remote cache manifest index")
-	}
-	return rc.provider.Push(ctx, *manifestIndexDesc, rc.Ref)
+	return rc.provider.Push(ctx, *cacheDesc, rc.Ref)
 }
 
 // update updates cache manifests, it preferentially keep the lower layers if the cache capacity is full.
 func (rc *RemoteCache) update(ctx context.Context, orgDesc, newDesc, cacheDesc *ocispec.Descriptor,
-	platformMC platforms.MatchComparer) (*ocispec.Index, error) {
+	platformMC platforms.MatchComparer) (*ocispec.Descriptor, []ocispec.Descriptor, error) {
 	targetLayersByPlatform := map[*platforms.Platform][]ocispec.Descriptor{}
 
 	switch orgDesc.MediaType {
 	case ocispec.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
 		targetLayers, err := rc.getTargetLayers(ctx, rc.provider.ContentStore(), *orgDesc)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		// platform of original or new image maybe lost, get from config platform
 		platform, err := images.Platforms(ctx, rc.provider.ContentStore(), *orgDesc)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		targetLayersByPlatform[&platform[0]] = targetLayers
 
 	case images.MediaTypeDockerSchema2ManifestList, ocispec.MediaTypeImageIndex:
 		orgManifests, err := utils.GetManifests(ctx, rc.provider.ContentStore(), *orgDesc, platformMC)
 		if err != nil {
-			return nil, errors.Wrap(err, "get source manifest list")
+			return nil, nil, errors.Wrap(err, "get source manifest list")
 		}
 		newManifests, err := utils.GetManifests(ctx, rc.provider.ContentStore(), *newDesc, platformMC)
 		if err != nil {
-			return nil, errors.Wrap(err, "get new manifest list")
+			return nil, nil, errors.Wrap(err, "get new manifest list")
 		}
 		for _, newManifestDesc := range newManifests {
 			targetLayers := []ocispec.Descriptor{}
 			newManiPlatforms, err := images.Platforms(ctx, rc.provider.ContentStore(), newManifestDesc)
 			if err != nil {
-				return nil, errors.Wrap(err, "get converted manifest platforms")
+				return nil, nil, errors.Wrap(err, "get converted manifest platforms")
 			}
 			// find original manifest matches converted manifest's platform
 			matcher := platforms.NewMatcher(newManiPlatforms[0])
 			for _, orgManifestDesc := range orgManifests {
 				orgManiPlatforms, err := images.Platforms(ctx, rc.provider.ContentStore(), orgManifestDesc)
 				if err != nil {
-					return nil, errors.Wrap(err, "get original manifest platforms")
+					return nil, nil, errors.Wrap(err, "get original manifest platforms")
 				}
 
 				if matcher.Match(orgManiPlatforms[0]) {
 					targetLayers, err = rc.getTargetLayers(ctx, rc.provider.ContentStore(), orgManifestDesc)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 					break
 				}
@@ -365,10 +383,10 @@ func (rc *RemoteCache) update(ctx context.Context, orgDesc, newDesc, cacheDesc *
 	imageConfig := ocispec.ImageConfig{}
 	imageConfigDesc, imageConfigBytes, err := nydusutils.MarshalToDesc(imageConfig, ocispec.MediaTypeImageConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "marshal remote cache image config")
+		return nil, nil, errors.Wrap(err, "marshal remote cache image config")
 	}
 	if err = content.WriteBlob(ctx, rc.provider.ContentStore(), rc.Ref, bytes.NewReader(imageConfigBytes), *imageConfigDesc); err != nil {
-		return nil, errors.Wrap(err, "write remote cahce image config")
+		return nil, nil, errors.Wrap(err, "write remote cahce image config")
 	}
 
 	cacheIndex := ocispec.Index{
@@ -380,37 +398,64 @@ func (rc *RemoteCache) update(ctx context.Context, orgDesc, newDesc, cacheDesc *
 	}
 	// cacheDesc maybe nil if remote cache doesn't exists before
 	if cacheDesc != nil {
-		_, err = utils.ReadJSON(ctx, rc.provider.ContentStore(), &cacheIndex, *cacheDesc)
-		if err != nil {
-			return nil, errors.Wrap(err, "read cache manifest index")
-		}
-		for idx, maniDesc := range cacheIndex.Manifests {
-			matcher := platforms.NewMatcher(*maniDesc.Platform)
-			for platform, layers := range targetLayersByPlatform {
-				if matcher.Match(*platform) {
-					// append new cache layers to existed cache manifest
-					var manifest ocispec.Manifest
-					_, err = utils.ReadJSON(ctx, rc.provider.ContentStore(), &manifest, maniDesc)
-					if err != nil {
-						return nil, errors.Wrap(err, "read cache manifest")
-					}
+		switch cacheDesc.MediaType {
+		case ocispec.MediaTypeImageManifest, images.MediaTypeDockerSchema2Manifest:
+			if len(targetLayersByPlatform) == 1 {
+				var manifest ocispec.Manifest
+				_, err = utils.ReadJSON(ctx, rc.provider.ContentStore(), &manifest, *cacheDesc)
+				if err != nil {
+					return nil, nil, errors.Wrap(err, "read cache manifest")
+				}
+				for platform, layers := range targetLayersByPlatform {
 					manifest.Layers = appendLayers(manifest.Layers, layers, rc.size)
-					// append LayerAnnotationCacheVersion to manifest annotations
 					if manifest.Annotations == nil {
 						manifest.Annotations = map[string]string{}
 					}
 					manifest.Annotations[LayerAnnotationCacheVersion] = rc.version
-					newManiDesc, err := utils.WriteJSON(ctx, rc.provider.ContentStore(), manifest, maniDesc, "", nil)
+					newManiDesc, err := utils.WriteJSON(ctx, rc.provider.ContentStore(), manifest, *cacheDesc, "", nil)
 					if err != nil {
-						return nil, errors.Wrap(err, "write cache manifest")
+						return nil, nil, errors.Wrap(err, "write cache manifest")
 					}
-					cacheIndex.Manifests[idx] = *newManiDesc
-					delete(targetLayersByPlatform, platform)
+					newManiDesc.Platform = platform
+					return newManiDesc, nil, nil
 				}
 			}
+		case ocispec.MediaTypeImageIndex, images.MediaTypeDockerSchema2ManifestList:
+			_, err = utils.ReadJSON(ctx, rc.provider.ContentStore(), &cacheIndex, *cacheDesc)
+			if err != nil {
+				return nil, nil, errors.Wrap(err, "read cache manifest index")
+			}
+			for idx, maniDesc := range cacheIndex.Manifests {
+				matcher := platforms.NewMatcher(*maniDesc.Platform)
+				for platform, layers := range targetLayersByPlatform {
+					if matcher.Match(*platform) {
+						// append new cache layers to existed cache manifest
+						var manifest ocispec.Manifest
+						_, err = utils.ReadJSON(ctx, rc.provider.ContentStore(), &manifest, maniDesc)
+						if err != nil {
+							return nil, nil, errors.Wrap(err, "read cache manifest")
+						}
+						manifest.Layers = appendLayers(manifest.Layers, layers, rc.size)
+						// append LayerAnnotationCacheVersion to manifest annotations
+						if manifest.Annotations == nil {
+							manifest.Annotations = map[string]string{}
+						}
+						manifest.Annotations[LayerAnnotationCacheVersion] = rc.version
+						newManiDesc, err := utils.WriteJSON(ctx, rc.provider.ContentStore(), manifest, maniDesc, "", nil)
+						if err != nil {
+							return nil, nil, errors.Wrap(err, "write cache manifest")
+						}
+						cacheIndex.Manifests[idx] = *newManiDesc
+						delete(targetLayersByPlatform, platform)
+					}
+				}
+			}
+		default:
+			return nil, nil, fmt.Errorf("unsupported cache image mediatype %s", cacheDesc.MediaType)
 		}
 	}
 
+	newManifests := []ocispec.Descriptor{}
 	// append new cache layers to new cache manifest
 	for platform, layers := range targetLayersByPlatform {
 		manifest := ocispec.Manifest{
@@ -424,18 +469,29 @@ func (rc *RemoteCache) update(ctx context.Context, orgDesc, newDesc, cacheDesc *
 				LayerAnnotationCacheVersion: rc.version,
 			},
 		}
-		manifestDesc, err := utils.WriteJSON(ctx, rc.provider.ContentStore(), manifest, ocispec.Descriptor{}, "", nil)
-		if err != nil {
-			return nil, errors.Wrap(err, "write cache manifest")
-		}
-		cacheIndex.Manifests = append(cacheIndex.Manifests, ocispec.Descriptor{
+		manifestDesc, err := utils.WriteJSON(ctx, rc.provider.ContentStore(), manifest, ocispec.Descriptor{
 			MediaType: ocispec.MediaTypeImageManifest,
-			Digest:    manifestDesc.Digest,
-			Size:      manifestDesc.Size,
 			Platform:  platform,
-		})
+		}, "", nil)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "write cache manifest")
+		}
+		newManifests = append(newManifests, *manifestDesc)
 	}
-	return &cacheIndex, nil
+
+	if cacheDesc == nil && len(newManifests) == 1 {
+		return &newManifests[0], nil, nil
+	}
+
+	cacheIndex.Manifests = append(cacheIndex.Manifests, newManifests...)
+	manifestIndexDesc, manifestIndexBytes, err := nydusutils.MarshalToDesc(cacheIndex, ocispec.MediaTypeImageIndex)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "marshal remote cache manifest index")
+	}
+	if err = content.WriteBlob(ctx, rc.provider.ContentStore(), rc.Ref, bytes.NewReader(manifestIndexBytes), *manifestIndexDesc); err != nil {
+		return nil, nil, errors.Wrap(err, "write remote cache manifest index")
+	}
+	return manifestIndexDesc, cacheIndex.Manifests, nil
 }
 
 // getTargetLayers gets cached target layers

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,283 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/plugins/content/local"
+	nydusify "github.com/containerd/nydus-snapshotter/pkg/converter"
+	"github.com/containerd/platforms"
+	nydusutils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
+	"github.com/goharbor/acceleration-service/pkg/utils"
+	digest "github.com/opencontainers/go-digest"
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchImportsSingleManifestCache(t *testing.T) {
+	ctx := context.Background()
+	cs := newTestContentStore(t)
+
+	sourceDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromString("source-layer"),
+		Size:      11,
+	}
+	targetDesc := newCacheLayer("target-layer")
+	targetDesc.Annotations[nydusify.LayerAnnotationNydusSourceDigest] = sourceDesc.Digest.String()
+
+	manifestDesc, manifestBytes := marshalCacheManifest(t, []ocispec.Descriptor{targetDesc}, "v1")
+	fetcher := &fakeFetcher{
+		blobs: map[digest.Digest][]byte{
+			manifestDesc.Digest: manifestBytes,
+			sourceDesc.Digest:   []byte("source"),
+		},
+		descs: map[digest.Digest]ocispec.Descriptor{
+			manifestDesc.Digest: *manifestDesc,
+			sourceDesc.Digest:   sourceDesc,
+		},
+	}
+	provider := &fakeProvider{
+		cs: cs,
+		resolver: &fakeResolver{
+			name:    "example.com/cache:tag",
+			desc:    *manifestDesc,
+			fetcher: fetcher,
+		},
+	}
+	rc := newTestRemoteCache(provider, 10)
+
+	desc, err := rc.Fetch(ctx, platforms.Default())
+	require.NoError(t, err)
+	require.Equal(t, ocispec.MediaTypeImageManifest, desc.MediaType)
+
+	item := rc.getBySource(sourceDesc.Digest)
+	require.NotNil(t, item)
+	require.Equal(t, sourceDesc.Digest, item.Source.Digest)
+	require.Equal(t, targetDesc.Digest, item.Target.Digest)
+	require.Equal(t, targetDesc.Digest.String(), item.Target.Annotations[nydusify.LayerAnnotationUncompressed])
+}
+
+func TestUpdateCreatesSinglePlatformManifestCache(t *testing.T) {
+	ctx := context.Background()
+	cs := newTestContentStore(t)
+	provider := &fakeProvider{cs: cs}
+	rc := newTestRemoteCache(provider, 10)
+
+	sourceDesc := newSourceLayer("source-layer")
+	targetDesc := newCacheLayer("target-layer")
+	rc.set(sourceDesc, targetDesc)
+
+	sourceManifestDesc := writeImageManifest(ctx, t, cs, []ocispec.Descriptor{sourceDesc}, linuxAMD64Image())
+
+	cacheDesc, manifests, err := rc.update(ctx, sourceManifestDesc, sourceManifestDesc, nil, platforms.Default())
+	require.NoError(t, err)
+	require.Empty(t, manifests)
+	require.Equal(t, ocispec.MediaTypeImageManifest, cacheDesc.MediaType)
+
+	var manifest ocispec.Manifest
+	_, err = utils.ReadJSON(ctx, cs, &manifest, *cacheDesc)
+	require.NoError(t, err)
+	require.Equal(t, ocispec.MediaTypeImageManifest, manifest.MediaType)
+	require.Equal(t, "v1", manifest.Annotations[LayerAnnotationCacheVersion])
+	require.Len(t, manifest.Layers, 1)
+	require.Equal(t, targetDesc.Digest, manifest.Layers[0].Digest)
+	require.Equal(t, sourceDesc.Digest.String(), manifest.Layers[0].Annotations[nydusify.LayerAnnotationNydusSourceDigest])
+}
+
+func TestUpdateMergesExistingSingleManifestCache(t *testing.T) {
+	ctx := context.Background()
+	cs := newTestContentStore(t)
+	provider := &fakeProvider{cs: cs}
+	rc := newTestRemoteCache(provider, 10)
+
+	oldTargetDesc := newCacheLayer("old-target-layer")
+	existingCacheDesc := writeCacheManifest(ctx, t, cs, []ocispec.Descriptor{oldTargetDesc}, "v1")
+
+	sourceDesc := newSourceLayer("source-layer")
+	targetDesc := newCacheLayer("target-layer")
+	rc.set(sourceDesc, targetDesc)
+
+	sourceManifestDesc := writeImageManifest(ctx, t, cs, []ocispec.Descriptor{sourceDesc}, linuxAMD64Image())
+
+	cacheDesc, manifests, err := rc.update(ctx, sourceManifestDesc, sourceManifestDesc, existingCacheDesc, platforms.Default())
+	require.NoError(t, err)
+	require.Empty(t, manifests)
+	require.Equal(t, ocispec.MediaTypeImageManifest, cacheDesc.MediaType)
+
+	var manifest ocispec.Manifest
+	_, err = utils.ReadJSON(ctx, cs, &manifest, *cacheDesc)
+	require.NoError(t, err)
+	require.Equal(t, "v1", manifest.Annotations[LayerAnnotationCacheVersion])
+	require.Len(t, manifest.Layers, 2)
+	require.Equal(t, oldTargetDesc.Digest, manifest.Layers[0].Digest)
+	require.Equal(t, targetDesc.Digest, manifest.Layers[1].Digest)
+}
+
+type fakeProvider struct {
+	cs       content.Store
+	resolver remotes.Resolver
+}
+
+func (p *fakeProvider) Resolver(_ string) (remotes.Resolver, error) {
+	return p.resolver, nil
+}
+
+func (p *fakeProvider) Pull(_ context.Context, _ string) error {
+	return nil
+}
+
+func (p *fakeProvider) Push(_ context.Context, _ ocispec.Descriptor, _ string) error {
+	return nil
+}
+
+func (p *fakeProvider) ContentStore() content.Store {
+	return p.cs
+}
+
+type fakeResolver struct {
+	name    string
+	desc    ocispec.Descriptor
+	fetcher remotes.Fetcher
+}
+
+func (r *fakeResolver) Resolve(_ context.Context, _ string) (string, ocispec.Descriptor, error) {
+	return r.name, r.desc, nil
+}
+
+func (r *fakeResolver) Fetcher(_ context.Context, _ string) (remotes.Fetcher, error) {
+	return r.fetcher, nil
+}
+
+func (r *fakeResolver) Pusher(_ context.Context, _ string) (remotes.Pusher, error) {
+	return nil, nil
+}
+
+type fakeFetcher struct {
+	blobs map[digest.Digest][]byte
+	descs map[digest.Digest]ocispec.Descriptor
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader(f.blobs[desc.Digest])), nil
+}
+
+func (f *fakeFetcher) FetchByDigest(_ context.Context, dgst digest.Digest, _ ...remotes.FetchByDigestOpts) (io.ReadCloser, ocispec.Descriptor, error) {
+	return io.NopCloser(bytes.NewReader(f.blobs[dgst])), f.descs[dgst], nil
+}
+
+func newTestRemoteCache(provider Provider, size int) *RemoteCache {
+	return &RemoteCache{
+		Ref:      "example.com/cache:tag",
+		provider: provider,
+		records:  map[digest.Digest]*Item{},
+		size:     size,
+		version:  "v1",
+	}
+}
+
+func newTestContentStore(t *testing.T) content.Store {
+	t.Helper()
+	cs, err := local.NewStore(t.TempDir())
+	require.NoError(t, err)
+	return cs
+}
+
+func newSourceLayer(seed string) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageLayer,
+		Digest:    digest.FromString(seed),
+		Size:      int64(len(seed)),
+	}
+}
+
+func newCacheLayer(seed string) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: "application/vnd.oci.image.layer.nydus.blob.v1",
+		Digest:    digest.FromString(seed),
+		Size:      int64(len(seed)),
+		Annotations: map[string]string{
+			"containerd.io/snapshot/nydus-blob": "true",
+		},
+	}
+}
+
+func linuxAMD64Image() ocispec.Image {
+	return ocispec.Image{
+		Platform: ocispec.Platform{
+			Architecture: "amd64",
+			OS:           "linux",
+		},
+		RootFS: ocispec.RootFS{
+			Type: "layers",
+		},
+	}
+}
+
+func writeImageManifest(ctx context.Context, t *testing.T, cs content.Store, layers []ocispec.Descriptor, image ocispec.Image) *ocispec.Descriptor {
+	t.Helper()
+	configDesc, configBytes, err := nydusutils.MarshalToDesc(image, ocispec.MediaTypeImageConfig)
+	require.NoError(t, err)
+	require.NoError(t, content.WriteBlob(ctx, cs, configDesc.Digest.String(), bytes.NewReader(configBytes), *configDesc))
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    *configDesc,
+		Layers:    layers,
+	}
+	manifestDesc, manifestBytes, err := nydusutils.MarshalToDesc(manifest, ocispec.MediaTypeImageManifest)
+	require.NoError(t, err)
+	require.NoError(t, content.WriteBlob(ctx, cs, manifestDesc.Digest.String(), bytes.NewReader(manifestBytes), *manifestDesc))
+	return manifestDesc
+}
+
+func writeCacheManifest(ctx context.Context, t *testing.T, cs content.Store, layers []ocispec.Descriptor, version string) *ocispec.Descriptor {
+	t.Helper()
+	manifestDesc, manifestBytes := marshalCacheManifest(t, layers, version)
+	require.NoError(t, content.WriteBlob(ctx, cs, manifestDesc.Digest.String(), bytes.NewReader(manifestBytes), *manifestDesc))
+	return manifestDesc
+}
+
+func marshalCacheManifest(t *testing.T, layers []ocispec.Descriptor, version string) (*ocispec.Descriptor, []byte) {
+	t.Helper()
+	configDesc, configBytes, err := nydusutils.MarshalToDesc(ocispec.ImageConfig{}, ocispec.MediaTypeImageConfig)
+	require.NoError(t, err)
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2,
+		},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    *configDesc,
+		Layers:    layers,
+		Annotations: map[string]string{
+			LayerAnnotationCacheVersion: version,
+		},
+	}
+	manifestDesc, manifestBytes, err := nydusutils.MarshalToDesc(manifest, ocispec.MediaTypeImageManifest)
+	require.NoError(t, err)
+	_ = configBytes
+	return manifestDesc, manifestBytes
+}


### PR DESCRIPTION
## Summary

This PR fixes Nydus remote cache handling when the cache image root is a single image manifest instead of a manifest list/image index.

Before this change, `RemoteCache.Fetch()` only accepted Docker manifest lists and OCI image indexes as cache roots. However, a cache image with only one platform can be represented as a single OCI image manifest. In that case, conversion fails after resolving the cache image with:

```text
unsupported cache image mediatype application/vnd.oci.image.manifest.v1+json
```

## What Changed

`RemoteCache.Fetch()` now accepts Docker schema2 manifests and OCI image manifests as valid cache image roots. When the cache root is a manifest, it is written into the local content store and its layer cache records are imported directly.

The cache-record import logic is shared by both index-selected manifests and top-level manifest cache images, so both layouts use the same cache version validation, source digest annotation validation, source descriptor lookup, and source-to-target record population.

`Push()` and `update()` no longer assume the cache root must always be an image index. `update()` now returns the descriptor that should be pushed as the cache image root.

The resulting behavior is:

- new single-platform cache image: push an image manifest as the root
- existing single-manifest cache image: update and push a manifest
- existing index cache image: preserve and update the index layout
- multi-platform cache image: push an image index as before

This avoids constructing a temporary manifest index just to support a single-manifest cache image.

## Unit Tests

Added `pkg/cache/cache_test.go` coverage for:

- importing records from a top-level single-manifest cache image
- creating a new single-platform cache as an image manifest root
- updating an existing single-manifest cache without converting it into an index

## Related Issue

This is related to #243. The behavior also matches the idea that a cache image with only one platform should not need to be represented as a manifest list.

## Testing

```text
go test ./pkg/cache
go test ./pkg/cache ./pkg/converter ./pkg/utils
```