### PR TITLE
HTTP API : Creation of a conversion tasks returns a task_id

### DIFF
--- a/cmd/accelctl/main.go
+++ b/cmd/accelctl/main.go
@@ -84,7 +84,8 @@ func main() {
 								logrus.Info("Waiting task to be completed...")
 							}
 
-							if err := ctl.CreateTask(source, sync); err != nil {
+							resp, err := ctl.CreateTask(source, sync)
+							if err != nil {
 								return err
 							}
 
@@ -92,6 +93,9 @@ func main() {
 								logrus.Info("Task has been completed.")
 							} else {
 								logrus.Info("Submitted asynchronous task, check status by `task list`.")
+							}
+							for _, t := range resp.Tasks {
+								logrus.Infof("Task ID: %s, Resource: %s", t.TaskID, t.ResourceURL)
 							}
 
 							return nil
@@ -145,7 +149,8 @@ func main() {
 						return err
 					}
 
-					return handler.Convert(c.Context, source, true)
+					_, err = handler.Convert(c.Context, source, true)
+					return err
 				},
 			},
 		},

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,7 @@ from Harbor for image conversions, acceld exposes following APIs:
 
 - [Create Task](#create-task)
 - [List Task](#list-task)
+- [Get Task](#get-task)
 - [Check Healthy](#check-healthy)
 
 ---
@@ -35,9 +36,20 @@ POST /api/v1/conversions?sync=$sync
 
 #### Response
 
+```json
+{
+    "tasks": [
+        {
+            "task_id": "5bdf7e80-1f1e-461f-a50d-f41d27434662",
+            "resource_url": "192.168.1.1/library/nginx:latest"
+        }
+    ]
+}
 ```
-Ok
-```
+
+`task_id`: string, unique identifier for the created conversion task. Can be used with [Get Task](#get-task) to track progress.
+
+`resource_url`: string, the source image reference associated with the task.
 
 | Status | Description                                  |
 | ------ | -------------------------------------------- |
@@ -83,6 +95,42 @@ GET /api/v1/conversions
 | ------ | -------------------------------------------- |
 | 200    | Return task list                             |
 | 401    | Unauthorized, invalid `Authorization` header |
+
+<a name="get-task"></a>
+
+### Get Task
+
+#### Request
+
+```
+GET /api/v1/conversions/:id
+```
+
+`id`: string, the task identifier returned by [Create Task](#create-task).
+
+#### Response
+
+```json
+{
+    "id": "5bdf7e80-1f1e-461f-a50d-f41d27434662",
+    "created": "2022-04-06T06:45:11.83226503Z",
+    "finished": "2022-04-06T06:45:11.948393604Z",
+    "source": "192.168.1.1/library/nginx:latest",
+    "source_size": "70254592",
+    "target_size": "72351744",
+    "status": "$status",
+    "reason": "$reason"
+}
+```
+
+`$status`: string, possible values is `PROCESSING`, `COMPLETED`, `FAILED`.
+
+`$reason`: string, giving failed reason message when the status is `FAILED`.
+
+| Status | Description                                  |
+| ------ | -------------------------------------------- |
+| 200    | Return task                                  |
+| 404    | Task not found                               |
 
 <a name="check-healthy"></a>
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -40,7 +40,7 @@ type Adapter interface {
 	// by specifying source image reference, the conversion is
 	// asynchronous, and if the sync option is specified,
 	// Dispatch will be blocked until the conversion is complete.
-	Dispatch(ctx context.Context, ref string, sync bool) error
+	Dispatch(ctx context.Context, ref string, sync bool) (string, error)
 	// CheckHealth checks the containerd client can successfully
 	// connect to the containerd daemon and the healthcheck service
 	// returns the SERVING response.
@@ -141,10 +141,10 @@ func (adp *LocalAdapter) Convert(ctx context.Context, source string) (*converter
 	return metric, nil
 }
 
-func (adp *LocalAdapter) Dispatch(ctx context.Context, ref string, sync bool) error {
+func (adp *LocalAdapter) Dispatch(ctx context.Context, ref string, sync bool) (string, error) {
 	taskID, err := task.Manager.Create(ref)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if sync {
 		// FIXME: The synchronous conversion task should also be
@@ -154,7 +154,7 @@ func (adp *LocalAdapter) Dispatch(ctx context.Context, ref string, sync bool) er
 			task.Manager.Finish(taskID, metric, err)
 			return nil, err
 		}, "convert")
-		return err
+		return taskID, err
 	}
 
 	adp.worker.Dispatch(func() error {
@@ -170,7 +170,7 @@ func (adp *LocalAdapter) Dispatch(ctx context.Context, ref string, sync bool) er
 		return err
 	})
 
-	return nil
+	return taskID, nil
 }
 
 func (adp *LocalAdapter) CheckHealth(_ context.Context) error {

--- a/pkg/client/convert.go
+++ b/pkg/client/convert.go
@@ -3,6 +3,7 @@ package client
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -35,10 +36,15 @@ func (client *Client) CreateTask(src string, sync bool) (*model.CreateTaskRespon
 	}
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read response body")
+	}
+
+	// Support both new server (JSON object response) and old server ("Ok" string response).
 	var result model.CreateTaskResponse
-	decoder := json.NewDecoder(resp.Body)
-	if err := decoder.Decode(&result); err != nil {
-		return nil, errors.Wrap(err, "decode response")
+	if err := json.Unmarshal(body, &result); err != nil || len(result.Tasks) == 0 {
+		return &model.CreateTaskResponse{}, nil
 	}
 
 	return &result, nil

--- a/pkg/client/convert.go
+++ b/pkg/client/convert.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/goharbor/acceleration-service/pkg/model"
 	"github.com/goharbor/acceleration-service/pkg/task"
@@ -42,9 +43,13 @@ func (client *Client) CreateTask(src string, sync bool) (*model.CreateTaskRespon
 	}
 
 	// Support both new server (JSON object response) and old server ("Ok" string response).
-	var result model.CreateTaskResponse
-	if err := json.Unmarshal(body, &result); err != nil || len(result.Tasks) == 0 {
+	if strings.TrimSpace(string(body)) == "Ok" {
 		return &model.CreateTaskResponse{}, nil
+	}
+
+	var result model.CreateTaskResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, errors.Wrap(err, "unmarshal response body")
 	}
 
 	return &result, nil
@@ -57,10 +62,6 @@ func (client *Client) GetTask(id string) (*task.Task, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("task %s not found", id)
-	}
 
 	var t task.Task
 	decoder := json.NewDecoder(resp.Body)

--- a/pkg/client/convert.go
+++ b/pkg/client/convert.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (client *Client) CreateTask(src string, sync bool) error {
+func (client *Client) CreateTask(src string, sync bool) (*model.CreateTaskResponse, error) {
 	payload := model.Payload{
 		Type: model.TopicPushArtifact,
 		EventData: &model.EventData{
@@ -25,17 +25,44 @@ func (client *Client) CreateTask(src string, sync bool) error {
 
 	data, err := marshal(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	path := fmt.Sprintf("/api/v1/conversions?sync=%s", strconv.FormatBool(sync))
 	resp, err := client.Request(http.MethodPost, path, data, nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
-	return nil
+	var result model.CreateTaskResponse
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&result); err != nil {
+		return nil, errors.Wrap(err, "decode response")
+	}
+
+	return &result, nil
+}
+
+func (client *Client) GetTask(id string) (*task.Task, error) {
+	path := fmt.Sprintf("/api/v1/conversions/%s", id)
+	resp, err := client.Request(http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("task %s not found", id)
+	}
+
+	var t task.Task
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&t); err != nil {
+		return nil, errors.Wrap(err, "decode response")
+	}
+
+	return &t, nil
 }
 
 func (client *Client) ListTask() ([]task.Task, error) {

--- a/pkg/errdefs/errors.go
+++ b/pkg/errdefs/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrAlreadyConverted = errors.New("ERR_ALREADY_CONVERTED")
 	ErrUnhealthy        = errors.New("ERR_UNHEALTHY")
 	ErrSameTag          = errors.New("ERR_SAME_TAG")
+	ErrNotFound         = errors.New("ERR_NOT_FOUND")
 )
 
 // isErrHTTPResponseToHTTPSClient returns whether err is

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -36,7 +36,7 @@ type Handler interface {
 	// source image reference, the conversion is asynchronous, and
 	// if the sync option is specified, the HTTP request will be
 	// blocked until the conversion is complete.
-	Convert(ctx context.Context, ref string, sync bool) error
+	Convert(ctx context.Context, ref string, sync bool) (string, error)
 	// CheckHealth checks the acceld service is healthy and can serve
 	// webhook request.
 	CheckHealth(ctx context.Context) error
@@ -71,7 +71,7 @@ func (handler *LocalHandler) Auth(_ context.Context, host string, authHeader str
 	return nil
 }
 
-func (handler *LocalHandler) Convert(ctx context.Context, ref string, sync bool) error {
+func (handler *LocalHandler) Convert(ctx context.Context, ref string, sync bool) (string, error) {
 	return handler.adp.Dispatch(ctx, ref, sync)
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -21,6 +21,17 @@ package model
 
 const TopicPushArtifact = "PUSH_ARTIFACT"
 
+// ConversionTask represents a single conversion task created from a POST request.
+type ConversionTask struct {
+	TaskID      string `json:"task_id"`
+	ResourceURL string `json:"resource_url"`
+}
+
+// CreateTaskResponse is the response body for POST /api/v1/conversions.
+type CreateTaskResponse struct {
+	Tasks []ConversionTask `json:"tasks"`
+}
+
 // Payload of notification event
 type Payload struct {
 	Type      string     `json:"type"`

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -44,6 +44,7 @@ func NewLocalRouter(handler handler.Handler) Router {
 func (router *LocalRouter) Register(server *echo.Echo) error {
 	server.POST("/api/v1/conversions", router.CreateTask)
 	server.GET("/api/v1/conversions", router.ListTask)
+	server.GET("/api/v1/conversions/:id", router.GetTask)
 	server.GET("/api/v1/health", router.CheckHealth)
 
 	// Any unexpected endpoint will return an error.

--- a/pkg/router/task_create.go
+++ b/pkg/router/task_create.go
@@ -65,14 +65,23 @@ func (r *LocalRouter) CreateTask(ctx echo.Context) error {
 		}
 	}
 
+	resp := model.CreateTaskResponse{
+		Tasks: make([]model.ConversionTask, 0, len(payload.EventData.Resources)),
+	}
+
 	for _, res := range payload.EventData.Resources {
-		if err := r.handler.Convert(ctx.Request().Context(), res.ResourceURL, sync); err != nil {
+		taskID, err := r.handler.Convert(ctx.Request().Context(), res.ResourceURL, sync)
+		if err != nil {
 			return util.ReplyError(
 				ctx, http.StatusInternalServerError, errdefs.ErrConvertFailed,
 				err.Error(),
 			)
 		}
+		resp.Tasks = append(resp.Tasks, model.ConversionTask{
+			TaskID:      taskID,
+			ResourceURL: res.ResourceURL,
+		})
 	}
 
-	return ctx.JSON(http.StatusOK, "Ok")
+	return ctx.JSON(http.StatusOK, resp)
 }

--- a/pkg/router/task_list.go
+++ b/pkg/router/task_list.go
@@ -25,3 +25,15 @@ func (r *LocalRouter) ListTask(ctx echo.Context) error {
 	tasks := task.Manager.List()
 	return ctx.JSON(http.StatusOK, tasks)
 }
+
+func (r *LocalRouter) GetTask(ctx echo.Context) error {
+	id := ctx.Param("id")
+	t := task.Manager.Get(id)
+	if t == nil {
+		return ctx.JSON(http.StatusNotFound, map[string]string{
+			"code":    "ERR_TASK_NOT_FOUND",
+			"message": "task not found",
+		})
+	}
+	return ctx.JSON(http.StatusOK, t)
+}

--- a/pkg/router/task_list.go
+++ b/pkg/router/task_list.go
@@ -17,6 +17,8 @@ package router
 import (
 	"net/http"
 
+	"github.com/goharbor/acceleration-service/pkg/errdefs"
+	"github.com/goharbor/acceleration-service/pkg/server/util"
 	"github.com/goharbor/acceleration-service/pkg/task"
 	echo "github.com/labstack/echo/v4"
 )
@@ -30,10 +32,7 @@ func (r *LocalRouter) GetTask(ctx echo.Context) error {
 	id := ctx.Param("id")
 	t := task.Manager.Get(id)
 	if t == nil {
-		return ctx.JSON(http.StatusNotFound, map[string]string{
-			"code":    "ERR_TASK_NOT_FOUND",
-			"message": "task not found",
-		})
+		return util.ReplyError(ctx, http.StatusNotFound, errdefs.ErrNotFound, "task not found")
 	}
 	return ctx.JSON(http.StatusOK, t)
 }

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -189,6 +189,13 @@ func (m *manager) Finish(id string, metric *converter.Metric, err error) error {
 	return nil
 }
 
+func (m *manager) Get(id string) *Task {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	return m.tasks[id]
+}
+
 func (m *manager) List() []*Task {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()


### PR DESCRIPTION
Fixes https://github.com/goharbor/acceleration-service/issues/368

# Context 

When requesting a task async (sync=false) :
* The POST /api/v1/conversions doesn't returns any body (outside of a ok) so it is impossible to get an identifer of the task
* THE GET /api/v1/conversions is a list of all the tasks

so it is impossible to get a reliable way of knowing the status of the task (only heuristics)

# Content of the feature 

This PR adds :
* a body response for the POST
* adds a GET /api/v1/conversions/{task_id} to easily get a specific task

# Breaking changes 

* HTTP API : Currently, the POST returns "OK" with a "Content-type: application/json" header . Do we accept this breaking change or should the answer be under some "Accept" header or a specific query parameter ? 
* Go API : 
  * Adapter.Dispatch signature changes . I looked on github and it doesn't seems to be used referenced in public repo outside of goharbor/acceleration-service
  * Handler.Converter signature changes . I looked on github and it doesn't seems to be used referenced in public repo outside of goharbor/acceleration-service