### PR TITLE
Multi platform : Inject `containerd.io/snapshot/nydus` to nydus converted index 

### DIFF
--- a/pkg/adapter/annotation/annotation.go
+++ b/pkg/adapter/annotation/annotation.go
@@ -38,6 +38,22 @@ func annotate(annotations map[string]string, appended map[string]string) map[str
 	return annotations
 }
 
+// AppendToIndex annotates only the index itself (not its child manifests).
+func AppendToIndex(ctx context.Context, cs content.Store, desc *ocispec.Descriptor, appended map[string]string) (*ocispec.Descriptor, error) {
+	if appended == nil {
+		return desc, nil
+	}
+
+	var index ocispec.Index
+	labels, err := utils.ReadJSON(ctx, cs, &index, *desc)
+	if err != nil {
+		return nil, errors.Wrap(err, "read manifest index")
+	}
+
+	index.Annotations = annotate(index.Annotations, appended)
+	return utils.WriteJSON(ctx, cs, index, *desc, "", labels)
+}
+
 func Append(ctx context.Context, cs content.Store, desc *ocispec.Descriptor, appended map[string]string) (*ocispec.Descriptor, error) {
 	if appended == nil {
 		return desc, nil

--- a/pkg/driver/nydus/nydus.go
+++ b/pkg/driver/nydus/nydus.go
@@ -250,7 +250,7 @@ func (d *Driver) Convert(ctx context.Context, provider accelcontent.Provider, so
 		return nil, err
 	}
 	if d.mergeManifest {
-		return d.makeManifestIndex(ctx, provider.ContentStore(), *image, *desc)
+		return d.makeManifestIndex(ctx, provider.ContentStore(), *image, *desc, sourceRef)
 	}
 	return desc, err
 }
@@ -345,10 +345,30 @@ func (d *Driver) convert(ctx context.Context, provider accelcontent.Provider, so
 		convertHooks,
 	)
 
-	return indexConvertFunc(ctx, cs, source)
+	desc, err := indexConvertFunc(ctx, cs, source)
+	if err != nil {
+		return nil, err
+	}
+
+	if images.IsIndexType(desc.MediaType) {
+		indexAnnotations := map[string]string{
+			annotationSourceDigest:    string(source.Digest),
+			annotationSourceReference: sourceRef,
+			annotationFsVersion:       d.fsVersion,
+		}
+		if version := detectBuilderVersion(ctx, d.builderPath); version != "" {
+			indexAnnotations[annotationBuilderVersion] = version
+		}
+		desc, err = annotation.AppendToIndex(ctx, cs, desc, indexAnnotations)
+		if err != nil {
+			return nil, errors.Wrap(err, "append index annotations")
+		}
+	}
+
+	return desc, nil
 }
 
-func (d *Driver) makeManifestIndex(ctx context.Context, cs content.Store, oci, nydus ocispec.Descriptor) (*ocispec.Descriptor, error) {
+func (d *Driver) makeManifestIndex(ctx context.Context, cs content.Store, oci, nydus ocispec.Descriptor, sourceRef string) (*ocispec.Descriptor, error) {
 	ociDescs, err := utils.GetManifests(ctx, cs, oci, d.platformMC)
 	if err != nil {
 		return nil, errors.Wrap(err, "get oci image manifest list")
@@ -381,11 +401,21 @@ func (d *Driver) makeManifestIndex(ctx context.Context, cs content.Store, oci, n
 
 	descs := append(ociDescs, nydusDescs...)
 
+	indexAnnotations := map[string]string{
+		annotationSourceDigest:    string(oci.Digest),
+		annotationSourceReference: sourceRef,
+		annotationFsVersion:       d.fsVersion,
+	}
+	if version := detectBuilderVersion(ctx, d.builderPath); version != "" {
+		indexAnnotations[annotationBuilderVersion] = version
+	}
+
 	index := ocispec.Index{
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
-		Manifests: descs,
+		Annotations: indexAnnotations,
+		Manifests:   descs,
 	}
 
 	indexDesc, indexBytes, err := nydusutils.MarshalToDesc(index, ocispec.MediaTypeImageIndex)

--- a/pkg/driver/nydus/nydus_test.go
+++ b/pkg/driver/nydus/nydus_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/plugins/content/local"
+	"github.com/containerd/platforms"
 	nydusutils "github.com/goharbor/acceleration-service/pkg/driver/nydus/utils"
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
@@ -373,6 +375,73 @@ func verifyPrependResults(ctx context.Context, t *testing.T, cs content.Store, o
 	emptyHistory := newConfig.History[0]
 	assert.Equal(t, "Nydus Converter", emptyHistory.CreatedBy, "empty layer should be created by Nydus Converter")
 	assert.Equal(t, "Nydus Empty Layer", emptyHistory.Comment, "empty layer comment should be correct")
+}
+
+func createIndexBlob(ctx context.Context, cs content.Store, manifests []ocispec.Descriptor) (*ocispec.Descriptor, error) {
+	index := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: manifests,
+	}
+
+	indexDesc, indexBytes, err := nydusutils.MarshalToDesc(index, ocispec.MediaTypeImageIndex)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal index")
+	}
+
+	labels := map[string]string{}
+	for i, desc := range manifests {
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = desc.Digest.String()
+	}
+	if err := content.WriteBlob(ctx, cs, indexDesc.Digest.String(), bytes.NewReader(indexBytes), *indexDesc, content.WithLabels(labels)); err != nil {
+		return nil, errors.Wrap(err, "write index blob")
+	}
+	return indexDesc, nil
+}
+
+func Test_makeManifestIndexAnnotations(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	cs, err := local.NewStore(tempDir)
+	require.NoError(t, err)
+
+	// Build a minimal OCI manifest to act as the source
+	config := ocispec.Image{
+		RootFS:  ocispec.RootFS{Type: "layers", DiffIDs: []digest.Digest{}},
+		History: []ocispec.History{},
+	}
+	configDesc, err := createConfigBlob(ctx, cs, ocispec.MediaTypeImageConfig, config)
+	require.NoError(t, err)
+
+	manifestDesc, err := createManifestBlob(ctx, cs, ocispec.MediaTypeImageManifest, []ocispec.Descriptor{}, *configDesc)
+	require.NoError(t, err)
+	manifestDesc.Platform = &ocispec.Platform{OS: "linux", Architecture: "amd64"}
+
+	// Build the source OCI index and a nydus index (same manifests for simplicity)
+	ociIndexDesc, err := createIndexBlob(ctx, cs, []ocispec.Descriptor{*manifestDesc})
+	require.NoError(t, err)
+
+	nydusIndexDesc, err := createIndexBlob(ctx, cs, []ocispec.Descriptor{*manifestDesc})
+	require.NoError(t, err)
+
+	d := &Driver{
+		fsVersion:  "6",
+		platformMC: platforms.All,
+	}
+
+	const sourceRef = "registry.example.com/test/image:v1"
+	resultDesc, err := d.makeManifestIndex(ctx, cs, *ociIndexDesc, *nydusIndexDesc, sourceRef)
+	require.NoError(t, err)
+
+	indexBytes, err := content.ReadBlob(ctx, cs, *resultDesc)
+	require.NoError(t, err)
+
+	var idx ocispec.Index
+	require.NoError(t, json.Unmarshal(indexBytes, &idx))
+
+	assert.Equal(t, ociIndexDesc.Digest.String(), idx.Annotations[annotationSourceDigest], "index should have source digest annotation")
+	assert.Equal(t, sourceRef, idx.Annotations[annotationSourceReference], "index should have source reference annotation")
+	assert.Equal(t, "6", idx.Annotations[annotationFsVersion], "index should have fs version annotation")
 }
 
 func Test_generateDockerEmptyLayer(t *testing.T) {


### PR DESCRIPTION
In case of multi platform images, annotations referencing the source images are added to the manifests but not to the index.

This PR adds the annotations to the index also : 
* `containerd.io/snapshot/nydus-builder-version` : same as on the manifest files 
* `containerd.io/snapshot/nydus-fs-version` : same as on the manifest files 
* `containerd.io/snapshot/nydus-source-digest` : it is referencing the source index (with a similar logic as for index that references the source index on the matching platform)
* `containerd.io/snapshot/nydus-source-reference` : same as on the manifest files 